### PR TITLE
Github Actions workflow: added CI to build docker image and push amd64 images to dockerhub

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,59 @@
+name: Build and Push amd64 Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  TZ: /usr/share/zoneinfo/Asia/Kathmandu
+  # 1m cache segment restore timeout to stop wasting resource time
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+  
+# workflow can only read this repo’s code but cannot change
+# workflow can push Docker or GHCR images
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Clone frappe_docker
+        run: git clone --depth=1 https://github.com/frappe/frappe_docker && cd frappe_docker
+
+      - name: Read repo var, Encode apps.json to base64, add-mask
+        run: |
+           echo "::add-mask::$(echo '$APPS_JSON' | base64 -w 0)" >> $GITHUB_ENV
+
+      - name: Docker buildX, Push Image, Use GHA Cache
+        run: |
+          cd frappe_docker
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg FRAPPE_PATH=https://github.com/frappe/frappe \
+            --build-arg FRAPPE_BRANCH=version-15 \
+            --build-arg PYTHON_VERSION=3.11.9 \
+            --build-arg NODE_VERSION=18.20.2 \
+            --build-arg APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }} \
+            --tag yarsalabs/nepal-compliance:v0.1.0 \
+            --file images/custom/Containerfile \
+            --cache-from=type=gha \
+            --cache-to=type=gha,mode=max \
+            --push .


### PR DESCRIPTION
**This PR adds Github Actions workflow for Docker builds and push amd64 images to [yarsalabs dockerhub](https://hub.docker.com/u/yarsalabs).**

- triggers only on the `master` branch.
- syncs with tz: `Asia/Kathmandu`
- 1 minute cache segment restore timeout to stop wasting resource time
- workflow perms: has `read` for codebase and `write` for packages
- uses the official [frappe_docker](https://github.com/frappe/frappe_docker) repo and their custom [Containerfile](https://github.com/frappe/frappe_docker/blob/main/images/custom/Containerfile).
- uses docker `buildx` for `linux/amd64` arch only.
- tries to use GHA Caching.
- uses static versioning `v0.1.0`
  
## todo:

- build and push `linux/arm64` arch
- create multi-arch manifest to support tags
- docker layer and github actions cache management 
