### PR TITLE
add paths-ignore to ignore .md files during docker build

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**/*.md'
 
 env:
   TZ: /usr/share/zoneinfo/Asia/Kathmandu


### PR DESCRIPTION
adds `paths-ignore` in `docker-build-push.yml` file to ignore all `.md` files in any directory, including subdirectories
* any changes to any `.md` files will not trigger actions to prevent unwanted runtime