### PR TITLE
fix frappe translation method issue #19

### DIFF
--- a/nepal_compliance/nepal_compliance/report/audit_log/audit_log.py
+++ b/nepal_compliance/nepal_compliance/report/audit_log/audit_log.py
@@ -23,7 +23,7 @@ def get_columns():
             "width": 150
         },
         { 
-            "label": "Document Reference", 
+            "label": _("Document Reference"), 
             "fieldtype": "Dynamic Link", 
             "options": "ref_doctype", 
             "fieldname": "docname", 

--- a/nepal_compliance/nepal_compliance/report/purchase_return_vat_register/purchase_return_vat_register.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_return_vat_register/purchase_return_vat_register.py
@@ -47,7 +47,6 @@ def execute(filters=None):
         },
         {
             'fieldname': 'total',
-            'label': _(''),
             'fieldtype': 'Data',
             'width': 150
         },

--- a/nepal_compliance/nepal_compliance/report/sales_return_vat_register/sales_return_vat_register.py
+++ b/nepal_compliance/nepal_compliance/report/sales_return_vat_register/sales_return_vat_register.py
@@ -60,7 +60,7 @@ def execute(filters=None):
 		},
 		{
 			'fieldname': 'owner',
-			'label': 'Owner',
+			'label': _('Owner'),
 			'fieldtype': 'Data',
 		},
 		{

--- a/nepal_compliance/nepal_compliance/report/sales_vat_register/sales_vat_register.py
+++ b/nepal_compliance/nepal_compliance/report/sales_vat_register/sales_vat_register.py
@@ -60,7 +60,7 @@ def execute(filters=None):
 		},
 		{
 			'fieldname': 'owner',
-			'label': 'Owner',
+			'label': _('Owner'),
 			'fieldtype': 'Data',
 		},
 		{


### PR DESCRIPTION
This PR will add and bind "Document Reference" of audit_log.py, "Owner" of sales_vat_register.py and sales_return_vat_register.py to translation method and also remove 'label': _('') being empty string. 
Resolve #19