### PR TITLE
replace cur_frm with modern methods frm and eval() with safe_eval() method

### DIFF
--- a/nepal_compliance/public/js/salary_slip.js
+++ b/nepal_compliance/public/js/salary_slip.js
@@ -111,8 +111,8 @@ frappe.call = function(opts) {
         isProcessing = true;
         isEndDateChange = true;
         try {
-            if (cur_frm) {
-                savedComponents = captureCurrentState(cur_frm);
+            if (frm) {
+                savedComponents = captureCurrentState(frm);
             } else {
                 console.log('No current form found for capture');
             }
@@ -123,20 +123,20 @@ frappe.call = function(opts) {
                     if (originalSuccess) {
                         originalSuccess(r);
                     }
-                    if (savedComponents && cur_frm) {
+                    if (savedComponents && frm) {
                         console.log('Starting restore process with:', {
                             hasEarnings: savedComponents.earnings?.length || 0,
                             hasDeductions: savedComponents.deductions?.length || 0,
-                            currentEarnings: cur_frm.doc.earnings?.length || 0,
-                            currentDeductions: cur_frm.doc.deductions?.length || 0
+                            currentEarnings: frm.doc.earnings?.length || 0,
+                            currentDeductions: frm.doc.deductions?.length || 0
                         });
                         setTimeout(() => {
-                            restoreComponents(cur_frm);
+                            restoreComponents(frm);
                         }, 1000);
                     } else {
                         console.log('Restore skipped:', {
                             hasSavedComponents: !!savedComponents,
-                            hasCurrentForm: !!cur_frm
+                            hasCurrentForm: !!frm
                         });
                     }
                 } finally {

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
-from frappe.utils import flt 
+from frappe.utils import flt
+from frappe.utils import safe_eval
 
 def prevent_invoice_deletion(doc, method):
     frappe.throw(_(f"Deletion of {doc.name} is not allowed due to compliance rule."))
@@ -13,7 +14,7 @@ def evaluate_tax_formula(formula, taxable_salary):
             'taxable_salary': taxable_salary,
             'if': lambda x, y, z: y if x else z
         }
-        result = eval(formula, {"__builtins__": {}}, context)
+        result = safe_eval(formula, {"__builtins__": {}}, context)
         return flt(result)    
     except Exception as e:
         frappe.log_error(f"Tax Formula Evaluation Error: {str(e)}\nFormula: {formula}")


### PR DESCRIPTION
## What is this PR doing ?
- The cur_frm global variable has been replaced with the newer frm method, following the updates in Frappe.
- The use of eval() has been replaced with safe_eval(), imported from Frappe. This change enhances security by validating the tax formula expressions, also mitigate potential risks associated with unsafe code execution.