### PR TITLE
add field validation for vat/pan of customer/supplier and fix importing safe_eval method

### DIFF
--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -6,7 +6,8 @@ from frappe import _
 def create_custom_fields():
     custom_fields = {
         "Company": [
-            {"fieldname": "logo_for_printing", "label": "Logo For Printing", "fieldtype": "Attach", "insert_after": "parent_company"}
+            {"fieldname": "logo_for_printing", "label": "Logo For Printing", "fieldtype": "Attach", "insert_after": "parent_company"},
+            {"fieldname": "company_vat_number", "label": "Vat/Pan Number", "fieldtype": "Int", "insert_after": "default_holiday_list"}
         ],
         "Employee": [
             {"fieldname": "date_picker", "label": "Date Picker", "fieldtype": "Date", "insert_after": "gender", "reqd": 0},
@@ -15,8 +16,12 @@ def create_custom_fields():
         "Expense Claim": [
             {"fieldname": "nepali_date", "label": "Neplai Date", "fieldtype": "Data", "insert_after": "posting_date", "in_list_view": 1, "in_standard_filter": 1}
         ],
+        "Supplier": [
+            {"fieldname": "supplier_vat_number", "label": "Supplier Vat/Pan Number", "fieldtype": "Int", "insert_after": "country"}
+        ],
         "Customer": [
             {"fieldname": "customer_code", "label": "Customer Code", "fieldtype": "Data", "insert_after": "customer_name", "reqd": 0},
+            {"fieldname": "customer_vat_number", "label": "Customer Vat/Pan Number", "fieldtype": "Int", "insert_after": "customer_group"}
         ],
         "Salary Slip": [
             {"fieldname": "nepali_start_date", "label": "Nepali Start Date", "fieldtype": "Data", "insert_after": "start_date"},

--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -14,7 +14,7 @@ def create_custom_fields():
             {"fieldname": "revised_salary", "label": "Revised Salary", "fieldtype": "Currency", "insert_after": "payroll_cost_center", "reqd": 1},
         ],
         "Expense Claim": [
-            {"fieldname": "nepali_date", "label": "Neplai Date", "fieldtype": "Data", "insert_after": "posting_date", "in_list_view": 1, "in_standard_filter": 1}
+            {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date", "in_list_view": 1, "in_standard_filter": 1}
         ],
         "Supplier": [
             {"fieldname": "supplier_vat_number", "label": "Supplier Vat/Pan Number", "fieldtype": "Int", "insert_after": "country"}

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -51,6 +51,7 @@ app_include_js = [
 # include js in doctype views
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 doctype_js = {
+    "Company": "public/js/validate.js",
     "Salary Slip" : "public/js/salary_slip.js",
     "Expense Claim": "public/js/bs_date.js",
     "Leave Application": "public/js/bs_date.js",
@@ -59,10 +60,14 @@ doctype_js = {
     "Leave Allocation": "public/js/bs_date.js",
     "Attendance": "public/js/bs_date.js",
     "Fiscal Year": "public/js/bs_date.js",
-    "Purchase Invoice": "public/js/bs_date.js","Purchase Order": "public/js/bs_date.js","Purchase Receipt": "public/js/bs_date.js",
-    "Sales Order": "public/js/bs_date.js","Delivery Note": "public/js/bs_date.js","Sales Invoice": "public/js/bs_date.js",
+    "Purchase Invoice": ["public/js/bs_date.js", "public/js/validate.js"],
+    "Purchase Order": "public/js/bs_date.js","Purchase Receipt": "public/js/bs_date.js",
+    "Sales Order": "public/js/bs_date.js","Delivery Note": "public/js/bs_date.js",
+    "Sales Invoice": ["public/js/bs_date.js", "public/js/validate.js"],
     "Payment Entry": "public/js/bs_date.js",
     "Journal Entry": "public/js/bs_date.js",
+    "Supplier": "public/js/validate.js",
+    "Customer": "public/js/validate.js",
     "Request for Quotation": "public/js/bs_date.js","Supplier Quotation": "public/js/bs_date.js", "Quotation": "public/js/bs_date.js",
     "Blanket Order": "public/js/bs_date.js",
     "Landed Cost Voucher": "public/js/bs_date.js",

--- a/nepal_compliance/public/js/validate.js
+++ b/nepal_compliance/public/js/validate.js
@@ -4,7 +4,7 @@ function validate_field_value(frm, field_name) {
     if (field_value) {
         var field_value_str = field_value.toString(); 
         if (field_value_str.length !== 9 || isNaN(field_value_str)) {
-            frappe.throw(__(`The field "${field_name}" must be exactly 9 digits and should be a valid VAT/PAN Number.`));
+            frappe.throw(frappe._('The field {0} must be exactly 9 digits and should be a valid VAT/PAN Number.', [field_name]));
             frappe.validated = false; 
             return true;
         }

--- a/nepal_compliance/public/js/validate.js
+++ b/nepal_compliance/public/js/validate.js
@@ -1,0 +1,85 @@
+function validate_field_value(frm, field_name) {
+    var field_value = frm.doc[field_name];
+    
+    if (field_value) {
+        var field_value_str = field_value.toString(); 
+        if (field_value_str.length !== 9 || isNaN(field_value_str)) {
+            frappe.throw(__(`The field "${field_name}" must be exactly 9 digits and should be a valid VAT/PAN Number.`));
+            frappe.validated = false; 
+            return true;
+        }
+    }
+    return false;
+}
+
+function validate_field(frm) {
+    var vat_number = frm.doc.vat_number ? frm.doc.vat_number.toString().trim() : '';
+    var customer_vat_number = frm.doc.customer_vat_number ? frm.doc.customer_vat_number.toString().trim() : '';
+    var supplier_vat_number = frm.doc.supplier_vat_number ? frm.doc.supplier_vat_number.toString().trim() : '';
+
+    if (vat_number === customer_vat_number || vat_number === supplier_vat_number) {
+        frappe.throw(__('Supplier VAT/PAN Number and Customer VAT/PAN Number should not be the same.'));
+        frappe.validated = false; 
+        return;
+    }
+    if (validate_field_value(frm, 'vat_number') || validate_field_value(frm, 'customer_vat_number') || validate_field_value(frm, 'supplier_vat_number')) {
+        return; 
+    }
+}
+
+function fetch_vat_number(frm, doc_type, field_name) {
+    var doc_field = (doc_type === "Supplier" || doc_type === "Customer") ? doc_type.toLowerCase() : 'company';
+    var field_map = doc_type === "Supplier" ? 'supplier_vat_number' : (doc_type === "Customer" ? 'customer_vat_number' : 'company_vat_number');
+    
+    if (frm.doc[doc_field] && !frm.doc[field_name]) {
+        frappe.db.get_value(doc_type, frm.doc[doc_field], field_map, function(value) {
+            if (value && value[field_map]) {
+                frm.set_value(field_name, value[field_map]);
+            } else {
+                frm.set_value(field_name, '');
+            }
+        });
+    }
+}
+
+frappe.ui.form.on("Sales Invoice", {
+    validate: function(frm) {
+        validate_field(frm);
+    },
+    customer: function(frm) {
+        fetch_vat_number(frm, 'Customer', 'vat_number');
+    },
+    onload: function(frm){
+        fetch_vat_number(frm, 'Company', 'supplier_vat_number');
+    }
+});
+
+frappe.ui.form.on("Purchase Invoice", {
+    validate: function(frm) {
+        validate_field(frm);
+    },
+    supplier: function(frm) {
+        fetch_vat_number(frm, 'Supplier', 'vat_number');
+    },
+    onload: function(frm){
+        fetch_vat_number(frm, 'Company', 'customer_vat_number');
+    }
+});
+
+frappe.ui.form.on("Company", {
+    validate: function(frm) {
+        validate_field_value(frm, 'company_vat_number');
+    }
+});
+
+frappe.ui.form.on("Supplier", {
+    validate: function(frm) {
+        validate_field_value(frm, 'supplier_vat_number');
+    }
+});
+
+frappe.ui.form.on("Customer", {
+    validate: function(frm) {
+        validate_field_value(frm, 'customer_vat_number');
+    }
+});

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 from frappe.utils import flt
-from frappe.utils import safe_eval
+from frappe.utils.safe_exec import safe_eval
 
 def prevent_invoice_deletion(doc, method):
     frappe.throw(_(f"Deletion of {doc.name} is not allowed due to compliance rule."))


### PR DESCRIPTION


### Proposed change
This PR add validation for Customer/Supplier, VAT/PAN details and also fix safe_eval importing method. 
#### What's this PR Includes ?
- Allow user to fill up their VAT/PAN detail while setting up their master such as company, supplier, customer. Filled VAT/PAN will be first validated before saving.
- VAT/PAN filled in the masters will be automatically fetched while making sales and purchase invoice.
  #### What is included in the validation ?
- Validation checks if the PAN/VAT Number is exactly 9 digits, also confirms that VAT/PAN of both supplier and customer can't be same while making invoices.


---

### Breaking change
Does this PR introduce any breaking change?
- [ ] ❌ Yes (describe impact below)
- [x] ✅ No
- [ ] 🫤 Unsure (needs review)
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [ ] 🐛 Bug Fix (`PATCH v0.0.x`)
- [ ] ⚡️ Feature (`MINOR v0.x.0`)
- [ ] 📚 Docs Update
- [ ] 🎨 Style/UI Change
- [ ] 🔄 Refactoring
- [x] 🚀 Performance
- [ ] ✅ Testing
- [ ] ⚙️ CI/CD Build
- [ ] 📝 Other (add your own)

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

### Related Issues/ PRs
<!-- 
If this PR fixes a bug or relates to another PR, link them below:
-->
- **Fixes** #123 (auto-close when merged)
- **Related to** #456 (reference for context)
