### PR TITLE
add one-click button for salary structure generation

### DIFF
--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -92,6 +92,9 @@ doctype_js = {
     "Bulk Salary Structure Assignment": "public/js/bs_date.js", "Employee Attendance Tool": 'public/js/bs_date.js'
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
+doctype_list_js = {
+    "Salary Component": "public/js/custom_button.js"
+}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 

--- a/nepal_compliance/public/js/custom_button.js
+++ b/nepal_compliance/public/js/custom_button.js
@@ -1,0 +1,42 @@
+frappe.listview_settings["Salary Component"] = {
+    onload: function (listview) {
+        const allowed_roles = ["System Manager", "HR Manager", "Accounts Manager"];
+        const has_allowed_role = allowed_roles.some(role => frappe.user.has_role(role));
+
+        if (has_allowed_role) {
+            listview.page.add_inner_button(__('Generate Salary Structures'), function () {
+                frappe.call({
+                    method: 'nepal_compliance.custom_code.payroll.salary_structure.create_salary_structures',
+                    callback: function (r) {
+                        if (!r.exc) {
+                            const messages = r.message || [];
+
+                            const created = messages.filter(msg => msg.includes("created"));
+                            const existing = messages.filter(msg => msg.includes("already exists"));
+
+                            if (created.length > 0) {
+                                frappe.msgprint({
+                                    title: __("New Salary Structures Created"),
+                                    message: created.join("<br>"),
+                                    indicator: "green",
+                                    wide: true
+                                });
+                            } else if (existing.length > 0) {
+                                frappe.msgprint({
+                                    title: __("No New Structures"),
+                                    message: existing.join("<br>"),
+                                    indicator: "orange",
+                                    wide: true
+                                });
+                            } else {
+                                frappe.msgprint(__("No salary structures processed."));
+                            }
+                        } else {
+                            frappe.msgprint(__('Error generating salary structures. Check server logs.'));
+                        }
+                    }
+                });
+            });
+        }
+    }
+};


### PR DESCRIPTION
### Proposed change
This PR introduces a custom button in the Salary Component Doctype that allows users to generate a Salary Structure for the company with a single click.

#### Changes Introduced

- Added a custom button labeled Generate Salary Structure in the Salary Component Doctype.
- Implemented server-side logic to create a Salary Structure linked to the selected company.
- Ensured the generated structure includes relevant fields and is properly linked.
- Added basic validations and error handling.
- Refactor salary_structure.py

This ensure supporting one click salary structure generation for all the company so far in particular instance with parent child relationship.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No

---

### Type of change
What type of change does this PR introduce?
- [x] ⚡️ Feature (`MINOR v0.x.0`)
- [x] 🔄 Refactoring
- [x] 🚀 Performance
---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

