### PR TITLE
dynamically skip VAT/PAN validation for individuals (Customer/Supplier)

### DIFF
--- a/nepal_compliance/cbms_api.py
+++ b/nepal_compliance/cbms_api.py
@@ -61,7 +61,7 @@ class CBMSIntegration:
                 "username": self.cbms_settings.user_name,
                 "password": self.cbms_settings.get_password("password"),
                 "seller_pan": self.cbms_settings.panvat_no,
-                "buyer_pan": self.doc.vat_number,  
+                "buyer_pan": self.doc.vat_number if self.doc.vat_number else "",  
                 "fiscal_year": fiscal_year,
                 "total_sales": self.doc.grand_total if not self.doc.is_return else abs(self.doc.grand_total), 
                 "taxable_sales_vat": abs(self.doc.net_total) if self.doc.is_return else (self.doc.net_total if self.doc.discount_amount else abs(self.doc.total)),
@@ -169,7 +169,7 @@ def post_sales_invoice_or_return_to_cbms(doc_name, method=None):
             is_async=True,
             doc=doc_name 
         )
-        frappe.msgprint(_("Invoice/Return has been queued for sending to CBMS"))
+        frappe.msgprint(_("Invoice/Return has been queued for sending to CBMS."))
         return {"message": _("Request processed successfully"), "status": "success"}
 
     except Exception as e:

--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -7,7 +7,7 @@ def create_custom_fields():
     custom_fields = {
         "Company": [
             {"fieldname": "logo_for_printing", "label": "Logo For Printing", "fieldtype": "Attach", "insert_after": "parent_company"},
-            {"fieldname": "company_vat_number", "label": "Vat/Pan Number", "fieldtype": "Data", "insert_after": "default_holiday_list"}
+            {"fieldname": "company_vat_number", "label": "Vat/Pan Number", "fieldtype": "Data", "insert_after": "default_holiday_list", "allow_on_submit": 1}
         ],
         "User": [
             {"fieldname": "use_ad_date", "label": "Use Ad Date", "fieldtype": "Check", "insert_after": "username",
@@ -20,11 +20,11 @@ def create_custom_fields():
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"}
         ],
         "Supplier": [
-            {"fieldname": "supplier_vat_number", "label": "Supplier Vat/Pan Number", "fieldtype": "Data", "insert_after": "country", "reqd": 1},
+            {"fieldname": "supplier_vat_number", "label": "Supplier Vat/Pan Number", "fieldtype": "Data", "insert_after": "country", "allow_on_submit": 1},
             {"fieldname": "supplier_email_address", "label": "Supplier Email Address", "fieldtype": "Data", "insert_after": "supplier_vat_number"}
         ],
         "Customer": [
-            {"fieldname": "customer_vat_number", "label": "Customer Vat/Pan Number", "fieldtype": "Data", "insert_after": "customer_group", "reqd": 1},
+            {"fieldname": "customer_vat_number", "label": "Customer Vat/Pan Number", "fieldtype": "Data", "insert_after": "customer_group", "allow_on_submit": 1},
             {"fieldname": "customer_email_address", "label": "Customer Email Address", "fieldtype": "Data", "insert_after": "customer_vat_number"}
         ],
         "Salary Slip": [
@@ -61,19 +61,18 @@ def create_custom_fields():
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"}
         ],  
         "Purchase Invoice":[
-            {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"},
-            {"fieldname": "vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "supplier", "in_list_view": 1, "reqd": 1},
-            {"fieldname": "customer_vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "reqd": 1},
+            {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date", "allow_on_submit": 1},
+            {"fieldname": "vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "supplier", "in_list_view": 1, "allow_on_submit": 1},
+            {"fieldname": "customer_vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "qr_code", "label": "QR Code", "fieldtype": "Attach", "insert_after": "customer_vat_number", "hidden": 1, "allow_on_submit": 1}
         ],
         "Sales Order":[
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "transaction_date"}
         ],
         "Sales Invoice": [
-            {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"},
-            {"fieldname": "print_count", "label": "Print Count", "fieldtype": "Int", "insert_after": "amended_form", "read_only": 1},
-            {"fieldname": "vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "customer", "in_list_view": 1, "reqd": 1},
-            {"fieldname": "supplier_vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "reqd": 1},
+            {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date", "allow_on_submit": 1},
+            {"fieldname": "vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "customer", "in_list_view": 1, "allow_on_submit": 1},
+            {"fieldname": "supplier_vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "qr_code", "label": "QR Code", "fieldtype": "Attach", "insert_after": "supplier_vat_number", "hidden": 1, "allow_on_submit": 1},
             {"fieldname": "reason", "label": "Reason For Return", "fieldtype": "Data", "insert_after": "supplier_vat_number", "depends_on": "eval:doc.is_return == 1", "mandatory_depends_on": "eval:doc.is_return == 1"},
             {"fieldname": "cbms_status", "label": "CBMS Status", "fieldtype": "Select", "options": "\nSuccess\nPending\nFailed", "default": "", "insert_after": "supplier_vat_number", "in_list_view": 1, "allow_on_submit": 1},

--- a/nepal_compliance/email_utils.py
+++ b/nepal_compliance/email_utils.py
@@ -75,7 +75,7 @@ def send_invoice_email(docname, doctype, auto_send=False):
     if not recipient_email :
         if not auto_send:
             frappe.msgprint(
-            _("No email address found for this Supplier/Customer. Please update their contact details."),
+            _("No email address found for this Supplier/Customer. Configure it in Supplier/Customer Doctype."),
             indicator="orange"
         )
         return
@@ -121,7 +121,7 @@ def check_email_setup(doctype, docname):
 
     if not email:
         frappe.msgprint(
-            _("No email address found for this Supplier/Customer. Please update their contact details."),
+            _("No email address found for this Supplier/Customer. Configure it in Supplier/Customer Doctype."),
             indicator="orange",
             alert=True
         )

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -69,10 +69,10 @@ doctype_js = {
     "Fiscal Year": "public/js/bs_date.js",
     "Stock Entry": "public/js/hrms_bs_date.js",
     "Material Request": "public/js/hrms_bs_date.js",
-    "Purchase Invoice": ["public/js/bs_date.js", "public/js/validate.js", "public/js/email.js", "public/js/utils.js"],
+    "Purchase Invoice": ["public/js/bs_date.js", "public/js/utils.js", "public/js/validate.js", "public/js/email.js"],
     "Purchase Order": "public/js/bs_date.js","Purchase Receipt": "public/js/bs_date.js",
     "Sales Order": "public/js/bs_date.js","Delivery Note": "public/js/bs_date.js",
-    "Sales Invoice": ["public/js/bs_date.js", "public/js/validate.js", "public/js/email.js", "public/js/utils.js"],
+    "Sales Invoice": ["public/js/bs_date.js", "public/js/utils.js", "public/js/validate.js", "public/js/email.js"],
     "CBMS Settings": "nepal_compliance/doctype/cbms_settings/cbms_settings.js",
     "Payment Entry": "public/js/bs_date.js",
     "Journal Entry": ["public/js/bs_date.js", "public/js/utils.js"],
@@ -206,11 +206,12 @@ doc_events = {
     },
     "Purchase Invoice" : {
         "on_trash": "nepal_compliance.utils.prevent_invoice_deletion",
-        "on_submit": ["nepal_compliance.qr_code.create_qr_code", "nepal_compliance.email_utils.send_email_on_submit"]
+        "before_insert": "nepal_compliance.utils.set_vat_numbers",
+        "on_submit": "nepal_compliance.qr_code.create_qr_code"
     },
     "Sales Invoice" : {
-        "on_submit": ["nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms", "nepal_compliance.qr_code.create_qr_code", "nepal_compliance.email_utils.send_email_on_submit",
-        ]
+        "before_insert": "nepal_compliance.utils.set_vat_numbers",
+        "on_submit": ["nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms", "nepal_compliance.qr_code.create_qr_code"],
     },
     "Salary Slip": {
         "after_insert": "nepal_compliance.patches.payroll_entry.execute",

--- a/nepal_compliance/public/js/bs_date.js
+++ b/nepal_compliance/public/js/bs_date.js
@@ -55,15 +55,35 @@ const nepaliDateConfig = {
             }
         }
     },
+    "Sales Invoice": {
+        hide_fields: ['nepali_date'],
+        date_pairs: [['posting_date', 'nepali_date']],
+        refresh_action(frm) {
+            if (!frm.is_new() && frm.doc.posting_date && !frm.doc.nepali_date) {
+                const nepali = convertADtoBS(frm.doc.posting_date);
+                frappe.db.set_value('Sales Invoice', frm.doc.name, 'nepali_date', nepali)
+                    .then(() => frm.reload_doc());
+            }
+        }
+    },
+    "Purchase Invoice": {
+        hide_fields: ['nepali_date'],
+        date_pairs: [['posting_date', 'nepali_date']],
+        refresh_action(frm) {
+            if (!frm.is_new() && frm.doc.posting_date && !frm.doc.nepali_date) {
+                const nepali = convertADtoBS(frm.doc.posting_date);
+                frappe.db.set_value('Purchase Invoice', frm.doc.name, 'nepali_date', nepali)
+                    .then(() => frm.reload_doc());
+            }
+        }
+    },
     "Leave Allocation": multipleNepaliDateConfig('from_date', 'to_date', 'from_nepali_date_leave_allocation', 'to_nepali_date_leave_allocation'),
     "Leave Application": multipleNepaliDateConfig('from_date', 'to_date', 'from_nepali_date_leave_application', 'to_nepali_date_leave_application'),
     "Holiday List": multipleNepaliDateConfig('from_date', 'to_date', 'nepali_from_date', 'nepali_to_date'),
     "Purchase Order": singleNepaliDateConfig('transaction_date'),
     "Purchase Receipt": singleNepaliDateConfig('posting_date'),
-    "Purchase Invoice": singleNepaliDateConfig('posting_date'),
     "Sales Order": singleNepaliDateConfig('transaction_date'),
     "Delivery Note": singleNepaliDateConfig('posting_date'),
-    "Sales Invoice": singleNepaliDateConfig('posting_date'),
     "Payment Entry": singleNepaliDateConfig('posting_date'),
     "Journal Entry": singleNepaliDateConfig('posting_date'),
     "Request for Quotation": singleNepaliDateConfig('transaction_date'),

--- a/nepal_compliance/public/js/validate.js
+++ b/nepal_compliance/public/js/validate.js
@@ -17,7 +17,7 @@ function validate_field(frm) {
     var customer_vat_number = frm.doc.customer_vat_number ? frm.doc.customer_vat_number.toString().trim() : '';
     var supplier_vat_number = frm.doc.supplier_vat_number ? frm.doc.supplier_vat_number.toString().trim() : '';
 
-    if (vat_number === customer_vat_number || vat_number === supplier_vat_number) {
+    if (vat_number && ((customer_vat_number && vat_number === customer_vat_number) || (supplier_vat_number && vat_number === supplier_vat_number))) {
         frappe.throw(__('Supplier VAT/PAN Number and Customer VAT/PAN Number should not be the same.'));
         frappe.validated = false; 
         return;
@@ -35,8 +35,6 @@ function fetch_vat_number(frm, doc_type, field_name) {
         frappe.db.get_value(doc_type, frm.doc[doc_field], field_map, function(value) {
             if (value && value[field_map]) {
                 frm.set_value(field_name, value[field_map]);
-            } else {
-                frm.set_value(field_name, '');
             }
         });
     }

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -19,4 +19,29 @@ def evaluate_tax_formula(formula, taxable_salary):
     except Exception as e:
         frappe.log_error(f"Tax Formula Evaluation Error: {str(e)}\nFormula: {formula}")
         return 0
-    
+
+
+def set_vat_numbers(doc, method):
+    if doc.get("__islocal") and doc.is_opening == "Yes":
+  
+        if doc.doctype == "Purchase Invoice":
+            if doc.supplier and not doc.vat_number:
+                supplier_vat = frappe.db.get_value("Supplier", doc.supplier, "supplier_vat_number")
+                if supplier_vat:
+                    doc.vat_number = supplier_vat
+
+            if doc.company and not doc.customer_vat_number:
+                company_vat = frappe.db.get_value("Company", doc.company, "company_vat_number")
+                if company_vat:
+                    doc.customer_vat_number = company_vat
+
+        elif doc.doctype == "Sales Invoice":
+            if doc.customer and not doc.vat_number:
+                customer_vat = frappe.db.get_value("Customer", doc.customer, "customer_vat_number")
+                if customer_vat:
+                    doc.vat_number = customer_vat
+
+            if doc.company and not doc.supplier_vat_number:
+                company_vat = frappe.db.get_value("Company", doc.company, "company_vat_number")
+                if company_vat:
+                    doc.supplier_vat_number = company_vat


### PR DESCRIPTION
### Proposed change

What is this PR doing ?
- Allows submission of documents for customers or suppliers without VAT/PAN as individuals.
- Auto capture vat/pan of customer and supplier making opening entries.
- Provides flexibility: If VAT/PAN is configured in master data (Customer/Supplier), it auto-fills; otherwise, the system proceeds without interruption.
- Allow user preference on configuring vat/pan. If configured it will automatically pull else work as it is.

Note:- For Sales Invoice sync with CBMS, you must configure PAN/VAT and related credentials in CBMS Settings
---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)
- [x] 🔄 Refactoring
- [x] 🚀 Performance

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

### Related Issues/ PRs
<!-- 
If this PR fixes a bug or relates to another PR, link them below:
-->
- **Fixes** #74
