### PR TITLE
add missing custom fields to sales and purchase doctypes

### DIFF
--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -11,12 +11,15 @@ def create_custom_fields():
         ],
         "Item": [
             {"fieldname": "is_nontaxable_item", "label": "Is Non-Taxable Item", "fieldtype": "Check", "insert_after": "is_stock_item"},
+            {"fieldname": "hs_code", "label": "H.S. Code", "fieldtype": "Data", "insert_after": "stock_uom", "description": "Harmonized System Code for the item, used for customs and trade purposes."}
         ],
         "Sales Invoice Item": [
             {"fieldname": "is_nontaxable_item", "label": "Is Non-Taxable Item", "fieldtype": "Check", "insert_after": "is_free_item", "fetch_from": "item_code.is_nontaxable_item", "read_only": 1},
+            {"fieldname": "hs_code", "label": "H.S. Code", "fieldtype": "Data", "insert_after": "uom", "fetch_from": "item_code.hs_code"}
         ],
         "Purchase Invoice Item": [
             {"fieldname": "is_nontaxable_item", "label": "Is Non-Taxable Item", "fieldtype": "Check", "insert_after": "is_free_item", "fetch_from": "item_code.is_nontaxable_item", "read_only": 1},
+            {"fieldname": "hs_code", "label": "H.S. Code", "fieldtype": "Data", "insert_after": "uom", "fetch_from": "item_code.hs_code"}
         ],
         "User": [
             {"fieldname": "use_ad_date", "label": "Use Ad Date", "fieldtype": "Check", "insert_after": "username",
@@ -74,6 +77,7 @@ def create_custom_fields():
             {"fieldname": "vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "supplier", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "customer_vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "qr_code", "label": "QR Code", "fieldtype": "Attach", "insert_after": "customer_vat_number", "hidden": 1, "allow_on_submit": 1},
+            {"fieldname": "reason", "label": "Reason For Return", "fieldtype": "Data", "insert_after": "customer_vat_number", "depends_on": "eval:doc.is_return == 1", "mandatory_depends_on": "eval:doc.is_return == 1"},
             {"fieldname": "customs_declaration_number", "label": "Customs Declaration Number", "fieldtype": "Data", "insert_after": "bill_no"}
         ],
         "Sales Order":[
@@ -87,7 +91,9 @@ def create_custom_fields():
             {"fieldname": "reason", "label": "Reason For Return", "fieldtype": "Data", "insert_after": "supplier_vat_number", "depends_on": "eval:doc.is_return == 1", "mandatory_depends_on": "eval:doc.is_return == 1"},
             {"fieldname": "cbms_status", "label": "CBMS Status", "fieldtype": "Select", "options": "\nSuccess\nPending\nFailed", "default": "", "insert_after": "supplier_vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "cbms_response", "label": "CBMS Response", "fieldtype": "Small Text", "insert_after": "cbms_status", "in_list_view": 1, "allow_on_submit": 1},
-            {"fieldname": "customs_declaration_number", "label": "Customs Declaration Number", "fieldtype": "Data", "insert_after": "due_date"}
+            {"fieldname": "customs_declaration_number", "label": "Customs Export Declaration Number", "fieldtype": "Data", "insert_after": "due_date", "depends_on": "eval:doc.supplier_country != 'Nepal'"},
+            {"fieldname": "customs_declaration_date", "label": "Customs Export Declaration Date", "fieldtype": "Date", "insert_after": "customs_declaration_number", "depends_on": "eval:doc.supplier_country != 'Nepal'"},
+            {"fieldname": "customs_declaration_date_bs", "label": "Customs Export Declaration Date BS", "fieldtype": "Data", "insert_after": "customs_declaration_date", "depends_on": "eval:doc.supplier_country != 'Nepal'"}
         ],
         "Delivery Note":[
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"}

--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -91,9 +91,9 @@ def create_custom_fields():
             {"fieldname": "reason", "label": "Reason For Return", "fieldtype": "Data", "insert_after": "supplier_vat_number", "depends_on": "eval:doc.is_return == 1", "mandatory_depends_on": "eval:doc.is_return == 1"},
             {"fieldname": "cbms_status", "label": "CBMS Status", "fieldtype": "Select", "options": "\nSuccess\nPending\nFailed", "default": "", "insert_after": "supplier_vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "cbms_response", "label": "CBMS Response", "fieldtype": "Small Text", "insert_after": "cbms_status", "in_list_view": 1, "allow_on_submit": 1},
-            {"fieldname": "customs_declaration_number", "label": "Customs Export Declaration Number", "fieldtype": "Data", "insert_after": "due_date", "depends_on": "eval:doc.supplier_country != 'Nepal'"},
-            {"fieldname": "customs_declaration_date", "label": "Customs Export Declaration Date", "fieldtype": "Date", "insert_after": "customs_declaration_number", "depends_on": "eval:doc.supplier_country != 'Nepal'"},
-            {"fieldname": "customs_declaration_date_bs", "label": "Customs Export Declaration Date BS", "fieldtype": "Data", "insert_after": "customs_declaration_date", "depends_on": "eval:doc.supplier_country != 'Nepal'"}
+            {"fieldname": "customs_declaration_number", "label": "Customs Export Declaration Number", "fieldtype": "Data", "insert_after": "cost_center", "allow_on_submit": 1},
+            {"fieldname": "customs_declaration_date", "label": "Customs Export Declaration Date", "fieldtype": "Date", "insert_after": "project", "allow_on_submit": 1},
+            {"fieldname": "customs_declaration_date_bs", "label": "Customs Export Declaration Date BS", "fieldtype": "Data", "insert_after": "customs_declaration_date", "allow_on_submit": 1}
         ],
         "Delivery Note":[
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date"}

--- a/nepal_compliance/public/js/bs_date.js
+++ b/nepal_compliance/public/js/bs_date.js
@@ -56,15 +56,25 @@ const nepaliDateConfig = {
         }
     },
     "Sales Invoice": {
-        hide_fields: ['nepali_date'],
-        date_pairs: [['posting_date', 'nepali_date']],
-        refresh_action(frm) {
-            if (!frm.is_new() && frm.doc.posting_date && !frm.doc.nepali_date) {
-                const nepali = convertADtoBS(frm.doc.posting_date);
-                frappe.db.set_value('Sales Invoice', frm.doc.name, 'nepali_date', nepali)
+    hide_fields: ['nepali_date', 'customs_declaration_date_bs'],
+    date_pairs: [
+        ['posting_date', 'nepali_date'],
+        ['customs_declaration_date', 'customs_declaration_date_bs']
+    ],
+    refresh_action(frm) {
+        const syncIfMissing = (adField, bsField) => {
+            if (!frm.doc[bsField] && frm.doc[adField]) {
+                const bs = convertADtoBS(frm.doc[adField]);
+                frappe.db.set_value('Sales Invoice', frm.doc.name, bsField, bs)
                     .then(() => frm.reload_doc());
             }
+        };
+
+        if (!frm.is_new()) {
+            syncIfMissing('posting_date', 'nepali_date');
+            syncIfMissing('customs_declaration_date', 'customs_declaration_date_bs');
         }
+    }
     },
     "Purchase Invoice": {
         hide_fields: ['nepali_date'],


### PR DESCRIPTION
### Proposed change

This PR add missing fields to purchase and sales doctypes.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "HS Code" field to Item, Sales Invoice Item, and Purchase Invoice Item forms.
  * Introduced "Reason" field in Sales Invoice and Purchase Invoice, shown and required only for returns.
  * Added "Customs Export Declaration Number," "Customs Declaration Date," and "Customs Declaration Date (BS)" fields to Sales Invoice and Sales Order, visible only when supplier country is not Nepal.

* **Enhancements**
  * Improved synchronization and visibility of Nepali date fields for customs declaration dates in Sales Invoice forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->