### PR TITLE
block sales invoice cancellation, always create credit note to maintain sequence and accounting

### DIFF
--- a/nepal_compliance/cbms_api.py
+++ b/nepal_compliance/cbms_api.py
@@ -41,12 +41,13 @@ class CBMSIntegration:
         vat = getattr(self.doc, "vat_number", None)
         tax = getattr(self.doc, "tax_id", None)
 
-        if vat and vat.strip():
-            return vat.strip()
-        elif tax and tax.strip():
-            return tax.strip()
+        pan = vat or tax or ""
+        pan = pan.strip()
+    
+        if pan and pan.isdigit():
+            return float(pan)
         else:
-            return ""
+            return None
 
     def prepare_payload(self):
         try:

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -145,7 +145,6 @@ after_sync = ["nepal_compliance.custom_code.payroll.salary_structure.create_sala
 # ------------
 
 # before_uninstall = "nepal_compliance.uninstall.before_uninstall"
-before_uninstall = "nepal_compliance.uninstall.before_uninstall"
 # after_uninstall = "nepal_compliance.uninstall.after_uninstall"
 
 # Integration Setup

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -145,6 +145,7 @@ after_sync = ["nepal_compliance.custom_code.payroll.salary_structure.create_sala
 # ------------
 
 # before_uninstall = "nepal_compliance.uninstall.before_uninstall"
+before_uninstall = "nepal_compliance.uninstall.before_uninstall"
 # after_uninstall = "nepal_compliance.uninstall.after_uninstall"
 
 # Integration Setup
@@ -188,6 +189,9 @@ after_sync = ["nepal_compliance.custom_code.payroll.salary_structure.create_sala
 # override_doctype_class = {
 # 	"ToDo": "custom_app.overrides.CustomToDo"
 # }
+override_doctype_class = {
+    "Sales Invoice": "nepal_compliance.overrides.custom_sales_invoice.CustomSalesInvoice"
+}
 
 # Document Events
 # ---------------
@@ -213,7 +217,7 @@ doc_events = {
     "Sales Invoice" : {
         "autoname": "nepal_compliance.utils.custom_autoname",
         "before_insert": "nepal_compliance.utils.set_vat_numbers",
-        "on_submit": ["nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms", "nepal_compliance.qr_code.create_qr_code"],
+        "on_submit": ["nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms", "nepal_compliance.qr_code.create_qr_code"]
     },
     "Salary Slip": {
         "after_insert": "nepal_compliance.patches.payroll_entry.execute",

--- a/nepal_compliance/overrides/custom_sales_invoice.py
+++ b/nepal_compliance/overrides/custom_sales_invoice.py
@@ -1,0 +1,7 @@
+import frappe
+from frappe import _
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice
+
+class CustomSalesInvoice(SalesInvoice):
+    def on_cancel(self):
+        frappe.throw(_(f"You cannot cancel {self.name}. Please create a Return / Credit Note instead."))


### PR DESCRIPTION
### Proposed change

This PR block cancellation of sales invoice, credit note need to be created to maintain sequence and accounting.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🔄 Refactoring
- [x] 🚀 Performance

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom Sales Invoice behavior that prevents cancellation of sales invoices. Users are now prompted to create a Return or Credit Note instead of cancelling an invoice.

* **Bug Fixes**
  * Improved validation of buyer PAN numbers to ensure only valid numeric PANs are processed.

* **Chores**
  * Updated internal configuration to use the custom Sales Invoice class for enhanced compliance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->