### PR TITLE
exclude auto tax for item marked as non-taxable, handle multiple items return details if included in single invoice

### DIFF
--- a/nepal_compliance/nepal_compliance/report/purchase_register_ird/purchase_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_register_ird/purchase_register_ird.py
@@ -13,7 +13,6 @@ def execute(filters=None):
 def get_columns():
     return [
         {"label": _("मिति"), "fieldname": "nepali_date", "fieldtype": "Data", "width": 120},
-        # {"label": "बीजक नं.", "fieldname": "invoice", "fieldtype": "Link", "options": "Purchase Invoice", "width": 100},
         {"label": _("बीजक नं."), "fieldname": "invoice", "fieldtype": "Data", "width": 200},
         {"label": _("प्रज्ञापनपत्र नं."), "fieldname": "customs_declaration_number", "fieldtype": "Data", "width": 130},
         {"label": _("आपूर्तिकर्ताको नाम"), "fieldname": "supplier_name", "fieldtype": "Data", "width": 160},
@@ -57,8 +56,9 @@ def get_data(filters):
 
     query = f"""
         SELECT
-            pi.name as invoice, pi.bill_no, pi.customs_declaration_number, pi.rounded_total, pi.nepali_date, pi.supplier_name, pi.tax_id as pan,
-            pi.total, pi.total_taxes_and_charges as total_tax, pi.supplier, pi.posting_date
+            pi.name as invoice, pi.bill_no, pi.customs_declaration_number, pi.rounded_total, pi.nepali_date,
+            pi.supplier_name, pi.tax_id as invoice_pan, pi.total, pi.total_taxes_and_charges as total_tax,
+            pi.supplier, pi.posting_date
         FROM `tabPurchase Invoice` pi
         LEFT JOIN `tabSupplier` s ON pi.supplier = s.name
         WHERE {' AND '.join(conditions)}
@@ -72,17 +72,25 @@ def get_data(filters):
         supplier_country = frappe.db.get_value("Supplier", inv.supplier, "country") or ""
         is_import = supplier_country.strip().lower() != "nepal"
 
+        pan = inv.invoice_pan or frappe.db.get_value("Supplier", inv.supplier, "tax_id")
+
         tax_exempt = taxable_domestic_nc = taxable_import_nc = capital_taxable_amount = 0.0
 
         item_filters = {"parent": inv.invoice}
-
         items = frappe.get_all("Purchase Invoice Item", filters=item_filters,
-            fields=["is_nontaxable_item", "net_amount", "amount", "asset_category"])
+            fields=["is_nontaxable_item", "net_amount", "amount", "asset_category", "item_tax_template"])
 
         for item in items:
             amt = flt(item.get("net_amount") or item.get("amount"))
 
-            if item.get("is_nontaxable_item"):
+            item_tax_template = item.get("item_tax_template")
+
+            is_nontaxable = (
+                item.get("is_nontaxable_item") or 
+                (flt(inv.total_tax) == 0 and not item_tax_template)
+            )
+
+            if is_nontaxable:
                 tax_exempt += amt
                 continue
 
@@ -95,21 +103,21 @@ def get_data(filters):
                     taxable_domestic_nc += amt
 
         total_taxable = taxable_domestic_nc + taxable_import_nc + capital_taxable_amount
-        # total_tax = flt(inv.total_tax)
+        total_tax = flt(inv.total_tax)
 
-        # tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax if total_taxable else 0
-        tax_domestic_nc = taxable_domestic_nc * 0.13 if total_taxable else 0  
-        # tax_import_nc = (taxable_import_nc / total_taxable) * total_tax if total_taxable else 0
-        tax_import_nc = taxable_import_nc * 0.13 if total_taxable else 0 
-        # tax_capital = (capital_taxable_amount / total_taxable) * total_tax if total_taxable else 0
-        tax_capital = capital_taxable_amount * 0.13 if total_taxable else 0 
+        if total_tax == 0 or total_taxable == 0:
+            tax_domestic_nc = tax_import_nc = tax_capital = 0
+        else:
+            tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax
+            tax_import_nc = (taxable_import_nc / total_taxable) * total_tax
+            tax_capital = (capital_taxable_amount / total_taxable) * total_tax
 
         data.append({
             "nepali_date": inv.nepali_date or inv.posting_date,
             "invoice": inv.bill_no if inv.bill_no else inv.invoice,
             "customs_declaration_number": inv.customs_declaration_number if is_import else "",
             "supplier_name": inv.supplier_name,
-            "pan": inv.pan,
+            "pan": pan,
             "total": inv.rounded_total,
             "tax_exempt": tax_exempt,
             "taxable_amount": taxable_domestic_nc,

--- a/nepal_compliance/nepal_compliance/report/purchase_return_register_ird/purchase_return_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_return_register_ird/purchase_return_register_ird.py
@@ -108,7 +108,7 @@ def get_data(filters):
         total_taxable = taxable_domestic_nc + taxable_import_nc + capital_taxable_amount
         total_tax = flt(inv.total_tax)
 
-        if total_tax == 0:
+        if total_tax == 0 or total_taxable == 0:
             tax_domestic_nc = tax_import_nc = tax_capital = 0
         else:
             tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax if total_taxable else 0

--- a/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.json
+++ b/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 1,
+ "add_total_row": 0,
  "add_translate_data": 0,
  "columns": [],
  "creation": "2025-07-04 13:09:48.253834",
@@ -11,7 +11,7 @@
  "is_standard": "Yes",
  "letter_head": "",
  "letterhead": null,
- "modified": "2025-07-04 13:09:48.253834",
+ "modified": "2025-08-22 15:14:00.771004",
  "modified_by": "Administrator",
  "module": "Nepal Compliance",
  "name": "Sales Return Register IRD",

--- a/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
@@ -105,6 +105,7 @@ def get_data(filters):
         for item in items:
             amt = flt(item.get("net_amount") or item.get("amount"))
             qty = flt(item.get("qty") or 0)
+            item_tax_template = item.get("item_tax_template")
             is_nontaxable = item.get("is_nontaxable_item") or (flt(inv.total_tax) == 0 and not item_tax_template)
             is_fixed_asset = item["item_code"] in asset_items
 


### PR DESCRIPTION
### Proposed change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Sales Return Register export now includes per-invoice subtotals and a final grand total row.
  - Reports display a dedicated PAN column and a plain invoice number column (non-clickable).

- Bug Fixes
  - More reliable PAN resolution from invoice or party details.
  - Correct handling of non-taxable items and fixed assets in all IRD registers.
  - Proportional tax distribution across categories replaces fixed-rate assumptions, with safeguards for zero-tax cases.

- Chores
  - Disabled built-in total row in Sales Return Register to align with the new grand total presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)
- [x] 🔄 Refactoring
- [x] 🚀 Performance

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

