### PR TITLE
clear nepali date and reload on bulk submission (sales invoice)

### DIFF
--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -223,7 +223,8 @@ doc_events = {
     "Sales Invoice" : {
         "autoname": "nepal_compliance.utils.custom_autoname",
         "before_insert": ["nepal_compliance.utils.set_vat_numbers", "nepal_compliance.utils.load_nepali_date"],
-        "on_submit": ["nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms", "nepal_compliance.qr_code.create_qr_code"]
+        "on_submit": "nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms",
+        "validate": "nepal_compliance.qr_code.create_qr_code"
     },
     "Salary Slip": {
         "after_insert": "nepal_compliance.patches.payroll_entry.execute",

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -78,5 +78,11 @@ def set_vat_numbers(doc, method):
                     doc.supplier_vat_number = company_vat
 
 def load_nepali_date(doc, method):
-    if hasattr(doc, "nepali_date"):
+    if not hasattr(doc, "nepali_date") or not hasattr(doc, "posting_date"):
+        return
+
+    posting_date_str = str(doc.posting_date).strip()
+    nepali_date_str = str(doc.nepali_date).strip() if doc.nepali_date else ""
+
+    if nepali_date_str and posting_date_str != nepali_date_str:
         doc.nepali_date = None


### PR DESCRIPTION
### Proposed change

This PR prevents carrying date from sales order to sales invoice when bulk invoices are generated from sales order.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)
- [x] 🔄 Refactoring

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sales Invoice creation now includes an additional pre-save step that initializes the Nepali date field when present, improving readiness for Nepali compliance workflows.
* **Bug Fixes**
  * Pre-save processing runs in a defined order so VAT numbers are set before date-related initialization, reducing chances of inconsistent data during invoice creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->