### PR TITLE
prevent taking valuse from leave ledger cache, instead allocate as per defined amount in leave type (develop -> master)

### DIFF
--- a/nepal_compliance/custom_code/leave_allocation/monthly_leave_bs.py
+++ b/nepal_compliance/custom_code/leave_allocation/monthly_leave_bs.py
@@ -28,11 +28,6 @@ class LeavePolicyAssignment(BaseLeavePolicyAssignment):
                 alloc_doc = frappe.get_doc("Leave Allocation", alloc.name)
 
                 if alloc_doc.total_leaves_allocated > monthly_amt:
-                    leaves_taken = frappe.db.sql("""SELECT SUM(leaves) FROM `tabLeave Ledger Entry` WHERE transaction_name = %s AND is_carry_forward = 0 """, (alloc_doc.name,))[0][0] or 0
-                    if abs(leaves_taken) >= monthly_amt:
-                        frappe.msgprint(_("Cannot reduce {0} allocation for {1}: employee has already used {2} days.").format(alloc_doc.leave_type, alloc_doc.employee, abs(leaves_taken)))
-                        continue
-  
                     reduce_by = alloc_doc.total_leaves_allocated - monthly_amt
 
                     create_leave_ledger_entry(alloc_doc, {


### PR DESCRIPTION
### Proposed change
This PR prevent taking value from leave ledger cache and allocate the defined amount of leave as per leave type.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)
- [x] ✅ Testing

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Leave allocation reductions can now be processed even when leaves have already been used by the employee, providing greater flexibility in leave management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->