### PR TITLE
Develop to master : cbms api for nepali date and date field intact in the form

### DIFF
--- a/nepal_compliance/cbms_api.py
+++ b/nepal_compliance/cbms_api.py
@@ -50,6 +50,7 @@ class CBMSIntegration:
             return None
 
     def prepare_payload(self):
+        from nepal_compliance.nepali_date_utils.nepali_date import format_bs
         try:
             if not self.cbms_settings:
                 self.cbms_settings = frappe.get_doc("CBMS Settings")
@@ -57,9 +58,6 @@ class CBMSIntegration:
             if not self.cbms_settings:
                 frappe.log_error("CBMS Settings not found", "CBMS API Error")
                 return None
-            
-            if not self.doc.nepali_date:
-                frappe.throw(_("Nepali date is missing in the Sales Invoice."))
 
             fiscal_year = frappe.db.get_value(
                 "Fiscal Year",
@@ -73,14 +71,13 @@ class CBMSIntegration:
             fiscal_year = self.convert_to_nepali_fy_format(fiscal_year)
 
             try:
-                date_obj = datetime.strptime(self.doc.nepali_date, "%Y-%m-%d")
-                invoice_date = date_obj.strftime("%Y.%m.%d")
+                invoice_date = format_bs(self.doc.posting_date, "YYYY.MM.DD")
             except ValueError as e:
-                frappe.log_error(f"Invalid Nepali date format: {self.doc.nepali_date}. Error: {str(e)}", "CBMS API Error")
+                frappe.log_error(f"Invalid Posting date format: {self.doc.posting_date}. Error: {str(e)}", "CBMS API Error")
                 return None
             except AttributeError as e:
-                frappe.msgprint(_("Nepali Date Missing"))
-                frappe.log_error("Nepali date is missing in the Sales Invoice.", "CBMS API Error")
+                frappe.msgprint(_("Posting Date Missing"))
+                frappe.log_error("Posting date is missing in the Sales Invoice.", "CBMS API Error")
                 return None
 
             datetimeclient = frappe.utils.now()

--- a/nepal_compliance/public/js/nepali_date_override.js
+++ b/nepal_compliance/public/js/nepali_date_override.js
@@ -212,13 +212,9 @@ function extend_with_bs_date_picker() {
             NepaliCalendarLib.render(pop, {
                 selectedDateBS: bs,
                 onSelect: (selected) => {
-                    const bsDate = selected.format({ format: "YYYY-MM-DD", calendar: "BS" });
                     const adDate = selected.format({ format: "YYYY-MM-DD", calendar: "AD" });
-                    const parsed = parseUserDate(bsDate, "YYYY-MM-DD");
-                    if (!parsed) {
-                        return;
-                    }
-                    const bsDisplay = formatDate(parsed.y, parsed.m, parsed.d, getUserDateFormat());
+                    const bsDisplay = NepaliFunctions.AD2BS(adDate, true);
+
                     this.safe_set_input(bsDisplay);
                     this.set_model_value(adDate);
                     
@@ -253,7 +249,7 @@ function extend_with_bs_date_picker() {
             try {
                 return NepaliFunctions.BS2AD(valueBS);
             } catch {
-                return null;
+                return valueBS;
             }
         }
 


### PR DESCRIPTION
### Proposed change

This PR refactors the CBMS api for sending Nepali dates using the available posting date as per the required format, also keeping the date field intact with the form.

---

### Breaking change
Does this PR introduce any breaking change?
- [x] ✅ No
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🔄 Refactoring

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [x] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date picker error handling to preserve user input when date conversion fails.
  * Refined posting date processing to eliminate unnecessary intermediate steps.

* **Improvements**
  * Enhanced Nepali date conversion display logic for more efficient date calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->