### PR TITLE
Remove 'payments' app from new-site command

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -79,7 +79,7 @@ services:
           fi
         done;
         echo "sites/common_site_config.json found";
-        bench new-site --mariadb-user-host-login-scope='%' --admin-password=${ADMIN_PASSWORD} --db-root-username=root --db-root-password=${DB_ROOT_PASSWORD} --install-app erpnext --install-app hrms --install-app payments --install-app nepal_compliance --set-default frontend;
+        bench new-site --mariadb-user-host-login-scope='%' --admin-password=${ADMIN_PASSWORD} --db-root-username=root --db-root-password=${DB_ROOT_PASSWORD} --install-app erpnext --install-app hrms --install-app nepal_compliance --set-default frontend;
         echo "Building nepal_compliance app...";
         bench build --app nepal_compliance;
 


### PR DESCRIPTION
This pull request makes a small change to the site creation process in the `compose.yaml` file by removing the installation of the `payments` app when creating a new site.

* Removed the `--install-app payments` flag from the `bench new-site` command in `compose.yaml`, so the `payments` app will no longer be installed by default during site creation.