### PR TITLE
Add stale workflow for issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
         # STALE LABEL / COMMENT
         stale-issue-label: stale-issue
         stale-pr-label: stale-pr
-        stale-issue-message: This PR has been automatically marked as stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+        stale-issue-message: This issue has been automatically marked as stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.
         stale-pr-message: This PR has been automatically marked as stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.
 
         # WHEN TO CLOSE AFTER STALE


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests. The workflow marks issues and PRs as stale after 30 days of inactivity, and closes them after an additional 7 days if there is still no activity.

**Automation of stale issue and PR management:**

* Added `.github/workflows/stale.yml` to schedule a daily job that uses the `actions/stale` action to mark issues and pull requests as stale after 30 days of inactivity, and close them after 7 more days if there is no response. Custom labels and messages are used, and certain labels are exempted from this automation.