### PR TITLE
Added Github Actions Stale for tracking inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,19 +15,14 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
          # WHEN TO MARK STALE
         days-before-stale: 30
-        days-before-issue-stale: 30
-        days-before-pr-stale: 30
+        # WHEN TO CLOSE AFTER STALE
+        days-before-close: 7
 
         # STALE LABEL / COMMENT
         stale-issue-label: stale-issue
         stale-pr-label: stale-pr
         stale-issue-message: This issue has been automatically marked as stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.
         stale-pr-message: This PR has been automatically marked as stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.
-
-        # WHEN TO CLOSE AFTER STALE
-        days-before-close: 7
-        days-before-issue-close: 7
-        days-before-pr-close: 7
         
         # COMMENTS WHEN CLOSED
         close-issue-message: This issue was closed automatically after being stale for 7 days.


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically manage stale issues and pull requests. The workflow marks issues and PRs as stale after 30 days of inactivity and closes them after 7 additional days if there is still no activity. It also provides customizable messages and label exemptions.

Workflow automation for stale issues and PRs:

* Added `.github/workflows/stale.yml` to schedule a daily job using `actions/stale@v10` that marks issues and pull requests as stale after 30 days of inactivity, and closes them 7 days later if there is still no activity. The workflow includes custom labels, messages, and label-based exemptions for both issues and PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated stale issue and pull request cleanup enabled: items inactive for 30 days will be marked as stale and automatically closed after an additional 7 days. Separate labels can exempt issues or PRs from this process (e.g., help wanted, documentation, WIP). Inline notifications are posted when items become stale and when they are closed to keep contributors informed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->