### PR TITLE
Nepali num2words - monkeypatch frappe's core in_words to support Crore Arba Kharba

### DIFF
--- a/nepal_compliance/__init__.py
+++ b/nepal_compliance/__init__.py
@@ -9,8 +9,11 @@ def _apply_patches():
 		from nepal_compliance.nepali_num2words import in_words
 		frappe.utils.in_words = in_words
 		frappe.utils.data.in_words = in_words
-	except ImportError as e:
-		frappe.log_error(f"Failed to apply patches for Nepal Compliance: {e}", "Nepal Compliance Patch Error")
+	except Exception as e:
+		try:
+			frappe.log_error(f"Failed to apply patches for Nepal Compliance: {e}", "Nepal Compliance Patch Error")
+		except Exception:
+			pass
 
 # Apply patches on import
 _apply_patches()

--- a/nepal_compliance/nepali_num2words.py
+++ b/nepal_compliance/nepali_num2words.py
@@ -3,7 +3,7 @@ import frappe
 def _nepali_in_words(integer: int) -> str:
 	"""
 	Manual Nepali number to words conversion using Arba/Kharba system.
-	Handles numbers up to 10^11 (Kharba).
+	Handles numbers up to 9,999,999,999,999 (99 Kharba).
 	"""
 	if integer < 0:
 		return "Minus " + _nepali_in_words(-integer)
@@ -92,8 +92,8 @@ def in_words(integer: int, in_million=True) -> str:
 			country = defaults.get("country")
 			if currency == "NPR" or country == "Nepal":
 				return _nepali_in_words(int(integer))
-		except Exception:
-			pass
+		except Exception as exc:
+			frappe.log_error(exc, "Error determining currency/country in nepali_num2words.in_words")
 		
 		locale = "en_IN"
 	else:


### PR DESCRIPTION
This pull request introduces a monkey patch to override Frappe's `in_words` function, ensuring that number-to-words conversion uses the Nepali numbering system (Arba/Kharba) when appropriate. It adds a new implementation for converting integers to words in the Nepali system, and conditionally applies this logic based on the user's currency or country settings.

Key changes include:

**Nepali Number-to-Words Implementation:**
* Added a new `_nepali_in_words` function in `nepal_compliance/nepali_num2words.py` to convert integers into Nepali-style words (using Kharba, Arba, Crore, Lakh, etc.), supporting numbers up to 10¹¹.
* Implemented a new `in_words` function that checks user defaults for currency or country, and uses the Nepali system if appropriate; otherwise, it falls back to the standard `num2words` package with locale detection.

**Monkey Patching Frappe:**
* On import of the `nepal_compliance` package, monkey patched Frappe's `in_words` function (in both `frappe.utils` and `frappe.utils.data`) to use the new Nepali-aware implementation, with error logging if the patch fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide Nepali number-to-words support: numbers render as Nepali text when appropriate (e.g., NPR or Nepal locale), with automatic locale detection and fallbacks to other languages. Handles zero and negative values, consistent large-number wording, and normalizes hyphens for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->