### PR TITLE
fix: pass employee_wise_accounting_enabled to set_accounting_entries_…

### DIFF
--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -167,8 +167,9 @@ class CustomPayrollEntry(PayrollEntry):
         bank_entry = None
         if salary_slip_total != 0:
             remark = "withheld salaries" if for_withheld_salaries else "salaries"
-            bank_entry = self.set_accounting_entries_for_bank_entry(salary_slip_total, remark)
-
+            bank_entry = self.set_accounting_entries_for_bank_entry(
+ 		   salary_slip_total, remark, employee_wise_accounting_enabled
+	    )
             if for_withheld_salaries:
                 link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
 


### PR DESCRIPTION
…for_bank_entry


fix(payroll): pass employee_wise_accounting_enabled to set_accounting_entries_for_bank_entry

The override of make_bank_entry in nepal_compliance called HRMS's
set_accounting_entries_for_bank_entry() with only 2 positional arguments
(salary_slip_total, remark), but the HRMS method signature requires a
third argument: employee_wise_accounting_enabled.

This caused the following error when clicking "Create Bank Entry" on a
Payroll Entry:

    TypeError: PayrollEntry.set_accounting_entries_for_bank_entry()
    missing 1 required positional argument: 'employee_wise_accounting_enabled'

The employee_wise_accounting_enabled variable is already computed earlier
in the same function (used in the `if employee_wise_accounting_enabled:`
branch above), so this is a one-line fix to pass it through.

Tested against hrms 15.59.0 / erpnext 15.96.1 / frappe 15.99.0.


### Breaking change
Does this PR introduce any breaking change?
NO


---

### Type of change
What type of change does this PR introduce?
- [ ] 🐛 Bug Fix (`PATCH v0.0.x`)

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [ ] 📖 Updated documentation as required.
- [ x ] ✅ All local tests passed with my changes.
- [ ] 🔍 Checked for duplicate PRs with similar changes.
- [ ] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

### Related Issues/ PRs
<!-- 
If this PR fixes a bug or relates to another PR, link them below:
-->
- **Fixes** #123 (auto-close when merged)
- **Related to** #456 (reference for context)
