### PR TITLE
feat: use base field from salary structure assignment to calculate salary and max benefits if basic salary > 60% of total salary. 

### DIFF
--- a/nepal_compliance/api/employee_benefit_claim.py
+++ b/nepal_compliance/api/employee_benefit_claim.py
@@ -28,7 +28,7 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
         filters={  
             "employee": employee,  
             "docstatus": 1,  
-            "from_date": ["<=", claim_date or date.today()]  
+            "from_date": ["<=", claim_date]  
         },  
         fields=["salary_structure", "from_date", "base"],  
         order_by="from_date desc",  

--- a/nepal_compliance/api/employee_benefit_claim.py
+++ b/nepal_compliance/api/employee_benefit_claim.py
@@ -17,11 +17,40 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
     if not emp.date_of_joining:
         return 0.0
 
-    base_salary = flt(emp.revised_salary) if getattr(emp, 'revised_salary', None) else flt(emp.ctc)
-
+    base_salary = flt(emp.revised_salary) if getattr(emp, 'revised_salary', None) else flt(emp.ctc) #revised salary or ctc
     if not base_salary:
         return 0.0
 
+    #check if base exists in salary structure assignment
+    # Get active salary structure assignment  
+    salary_structure_assignments = frappe.db.get_all(  
+        "Salary Structure Assignment",  
+        filters={  
+            "employee": employee,  
+            "docstatus": 1,  
+            "from_date": ["<=", claim_date or date.today()]  
+        },  
+        fields=["salary_structure", "from_date"],  
+        order_by="from_date desc",  
+        limit=1  
+    )  
+      
+    if not salary_structure_assignments:  
+        return 0.0
+        
+    salary_structure_assignment = salary_structure_assignments[0]
+
+    # Get base from Basic Salary component in the salary structure  
+    base_salary_sal_str = frappe.db.get_value(  
+        "Salary Detail",  
+        {  
+            "parent": salary_structure_assignment.salary_structure,  
+            "salary_component": "Basic Salary",  
+            "parenttype": "Salary Structure"  
+        },  
+        "amount"  
+    ) or 0  
+    
     doj = getdate(emp.date_of_joining)
     claim_dt = getdate(claim_date) if claim_date else date.today()
     from dateutil.relativedelta import relativedelta
@@ -33,7 +62,7 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
         months_worked = 0
 
     if months_worked >= 12:
-        return flt(base_salary * 0.6)
+        return flt(max(base_salary * 0.6, base_salary_sal_str))
     else:
-        per_month = flt((base_salary * 0.6) / 12.0)
+        per_month = flt(max((base_salary * 0.6), base_salary_sal_str) / 12.0)
         return flt(per_month * months_worked)

--- a/nepal_compliance/api/employee_benefit_claim.py
+++ b/nepal_compliance/api/employee_benefit_claim.py
@@ -21,7 +21,8 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
     if not base_salary:
         return 0.0
 
-    #check if base exists in salary structure assignment
+    # Fetch the latest active Salary Structure Assignment as of the claim date
+    # and use its `base` (per-employee override) as the eligibility floor.
     # Get active salary structure assignment  
     salary_structure_assignments = frappe.db.get_all(  
         "Salary Structure Assignment",  

--- a/nepal_compliance/api/employee_benefit_claim.py
+++ b/nepal_compliance/api/employee_benefit_claim.py
@@ -30,7 +30,7 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
             "docstatus": 1,  
             "from_date": ["<=", claim_date or date.today()]  
         },  
-        fields=["salary_structure", "from_date"],  
+        fields=["salary_structure", "from_date", "base"],  
         order_by="from_date desc",  
         limit=1  
     )  
@@ -38,18 +38,7 @@ def get_max_amount_eligible(employee: str, claim_date: Optional[Union[str, date]
     if not salary_structure_assignments:  
         return 0.0
         
-    salary_structure_assignment = salary_structure_assignments[0]
-
-    # Get base from Basic Salary component in the salary structure  
-    base_salary_sal_str = frappe.db.get_value(  
-        "Salary Detail",  
-        {  
-            "parent": salary_structure_assignment.salary_structure,  
-            "salary_component": "Basic Salary",  
-            "parenttype": "Salary Structure"  
-        },  
-        "amount"  
-    ) or 0  
+    base_salary_sal_str = flt(salary_structure_assignments[0].base)
     
     doj = getdate(emp.date_of_joining)
     claim_dt = getdate(claim_date) if claim_date else date.today()

--- a/nepal_compliance/custom_code/payroll/salary_component.py
+++ b/nepal_compliance/custom_code/payroll/salary_component.py
@@ -122,7 +122,7 @@ def create_multiple_salary_components():
             },
             {
                 "amount_based_on_formula": 1,
-                "formula": "(revised_salary if revised_salary else ctc) * .6",
+                "formula": "base if base else (revised_salary if revised_salary else ctc) * .6",
                 "name": "Basic Salary",
                 "salary_component": "Basic Salary",
                 "salary_component_abbr": "basic_salary",

--- a/nepal_compliance/overrides/employee_benefit_claim.py
+++ b/nepal_compliance/overrides/employee_benefit_claim.py
@@ -5,7 +5,7 @@ from datetime import date
 from hrms.hr.utils import validate_active_employee
 from hrms.payroll.doctype.payroll_period.payroll_period import get_payroll_period
 from hrms.payroll.doctype.employee_benefit_claim.employee_benefit_claim import EmployeeBenefitClaim as HRMSEmployeeBenefitClaim
-
+from nepal_compliance.api.employee_benefit_claim import get_max_amount_eligible
 
 class CustomEmployeeBenefitClaim(HRMSEmployeeBenefitClaim):
     def validate(self):
@@ -16,7 +16,8 @@ class CustomEmployeeBenefitClaim(HRMSEmployeeBenefitClaim):
 
         self.ensure_festival_allowance_not_already_claimed()
 
-        max_benefits = self.set_max_amount_eligible(self.employee, self.claim_date)
+        max_benefits = get_max_amount_eligible(self.employee, self.claim_date)
+        self.max_amount_eligible = max_benefits
 
         if not self.claimed_amount or flt(self.claimed_amount) == 0:
             self.claimed_amount = max_benefits
@@ -69,42 +70,3 @@ class CustomEmployeeBenefitClaim(HRMSEmployeeBenefitClaim):
                     formatdate(payroll_period.end_date),
                 )
             )
-
-    def set_max_amount_eligible(self, employee, claim_date):
-        if not employee:
-            self.max_amount_eligible = 0
-            return self.max_amount_eligible
-
-        emp = frappe.get_doc("Employee", employee)
-
-        if not emp.date_of_joining:
-            self.max_amount_eligible = 0
-            return self.max_amount_eligible
-
-        base_salary = flt(emp.revised_salary) if emp.revised_salary else flt(emp.ctc)
-        if not base_salary:
-            self.max_amount_eligible = 0
-            return self.max_amount_eligible
-
-        doj = getdate(emp.date_of_joining)
-        source_date = claim_date or getattr(self, "claim_date", None)
-        claim_dt = getdate(source_date) if source_date else date.today()
-
-        if doj > claim_dt:
-            self.max_amount_eligible = 0
-            return self.max_amount_eligible
-
-        months_worked = (claim_dt.year - doj.year) * 12 + (claim_dt.month - doj.month)
-        if claim_dt.day < doj.day:
-            months_worked -= 1
-
-        if months_worked < 0:
-            months_worked = 0
-
-        if months_worked >= 12:
-            self.max_amount_eligible = flt(base_salary * 0.6)
-        else:
-            per_month_ctc = flt((base_salary * 0.6) / 12.0)
-            self.max_amount_eligible = flt(per_month_ctc * months_worked)
-
-        return self.max_amount_eligible

--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -167,8 +167,9 @@ class CustomPayrollEntry(PayrollEntry):
         bank_entry = None
         if salary_slip_total != 0:
             remark = "withheld salaries" if for_withheld_salaries else "salaries"
-            bank_entry = self.set_accounting_entries_for_bank_entry(salary_slip_total, remark)
-
+            bank_entry = self.set_accounting_entries_for_bank_entry(
+ 		   salary_slip_total, remark, employee_wise_accounting_enabled
+	    )
             if for_withheld_salaries:
                 link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
 


### PR DESCRIPTION
### Proposed change
<!--
when basic salary = 0.6 x total no worries
but when basic_salary >0.6 x  total salary, then current modification helps

it checks the base component of salary structure assignment and then use it in salary component. (bench migrate required)
it also uses the same base component of salary structure assignment to calculate max allowed beneift in festival allowance

### Breaking change
Does this PR introduce any breaking change?
- [ ] ❌ Yes (describe impact below)
- [ x] ✅ No
- [ ] 🫤 Unsure (needs review)
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [ ] 🐛 Bug Fix (`PATCH v0.0.x`)
- [x ] ⚡️ Feature (`MINOR v0.x.0`)
- [ ] 📚 Docs Update
- [ ] 🎨 Style/UI Change
- [ ] 🔄 Refactoring
- [ ] 🚀 Performance
- [ ] ✅ Testing
- [ ] ⚙️ CI/CD Build
- [ ] 📝 Other (add your own)

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [ ] 📖 Updated documentation as required.
- [x ] ✅ All local tests passed with my changes.
- [ ] 🔍 Checked for duplicate PRs with similar changes.
- [ ] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

### Related Issues/ PRs
<!-- 
If this PR fixes a bug or relates to another PR, link them below:
-->
- **Fixes** #123 (auto-close when merged)
- **Related to** #456 (reference for context)
