### PR TITLE
fix(payroll): consolidate flex-benefit JEs and fix signature drift

### DIFF
--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -1,5 +1,6 @@
 import frappe, traceback
 from frappe import _
+from collections import defaultdict
 from hrms.payroll.doctype.salary_slip.salary_slip import SalarySlip
 from hrms.payroll.doctype.salary_slip.salary_slip import make_loan_repayment_entry
 from frappe.utils import cint
@@ -34,7 +35,7 @@ class CustomPayrollEntry(PayrollEntry):
     def submit_salary_slips(self):
         self.check_permission("write")
         salary_slips = self.get_sal_slip_list(ss_status=0)
-        
+
         if len(salary_slips) > 30 or frappe.flags.enqueue_payroll_entry:
             self.db_set("status", "Queued")
             frappe.enqueue(
@@ -100,11 +101,18 @@ class CustomPayrollEntry(PayrollEntry):
         self.check_permission("write")
         self.employee_based_payroll_payable_entries = {}
         employee_wise_accounting_enabled = frappe.db.get_single_value(
-        "Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
-    )
+            "Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
+        )
 
         salary_slip_total = 0
         salary_details = self.get_salary_slip_details(for_withheld_salaries)
+
+        # Accumulator for flex-benefit components paid via separate JE.
+        # Keyed by salary_component, value is list of
+        # (employee, amount, salary_structure) tuples for every claimant.
+        # Emitted as one consolidated JE per component AFTER the main
+        # bank entry, with employee-wise rows so each claim is traceable.
+        flex_benefit_claims = defaultdict(list)
 
         for sd in salary_details:
             if not sd.salary_component:
@@ -112,16 +120,16 @@ class CustomPayrollEntry(PayrollEntry):
 
             if sd.parentfield == "earnings":
                 result = frappe.db.get_value(
-                "Salary Component",
-                sd.salary_component,
-                (
-                    "is_flexible_benefit",
-                    "only_tax_impact",
-                    "create_separate_payment_entry_against_benefit_claim",
-                    "statistical_component",
-                ),
-                cache=True,
-            )
+                    "Salary Component",
+                    sd.salary_component,
+                    (
+                        "is_flexible_benefit",
+                        "only_tax_impact",
+                        "create_separate_payment_entry_against_benefit_claim",
+                        "statistical_component",
+                    ),
+                    cache=True,
+                )
 
                 if result:
                     is_flexible_benefit, only_tax_impact, create_separate_je, statistical_component = result
@@ -130,50 +138,83 @@ class CustomPayrollEntry(PayrollEntry):
 
                 if only_tax_impact != 1 and statistical_component != 1:
                     if is_flexible_benefit == 1 and create_separate_je == 1:
-                        self.set_accounting_entries_for_bank_entry(
-                        sd.amount, sd.salary_component
-                    )
+                        # Defer: don't create a JE inside the loop. Collect
+                        # every (employee, amount) so we can produce ONE
+                        # consolidated JE per component after the main run.
+                        flex_benefit_claims[sd.salary_component].append(
+                            (sd.employee, sd.amount, sd.salary_structure)
+                        )
                     else:
                         if employee_wise_accounting_enabled:
                             self.set_employee_based_payroll_payable_entries(
-                            "earnings",
-                            sd.employee,
-                            sd.amount,
-                            sd.salary_structure,
-                        )
-                    salary_slip_total += sd.amount
+                                "earnings",
+                                sd.employee,
+                                sd.amount,
+                                sd.salary_structure,
+                            )
+                        salary_slip_total += sd.amount
 
             elif sd.parentfield == "deductions":
                 statistical_component = frappe.db.get_value(
-                "Salary Component",
-                sd.salary_component,
-                "statistical_component",
-                cache=True,
-            ) or 0
+                    "Salary Component",
+                    sd.salary_component,
+                    "statistical_component",
+                    cache=True,
+                ) or 0
 
                 if not statistical_component:
                     if employee_wise_accounting_enabled:
                         self.set_employee_based_payroll_payable_entries(
-                        "deductions",
-                        sd.employee,
-                        sd.amount,
-                        sd.salary_structure,
-                    )
+                            "deductions",
+                            sd.employee,
+                            sd.amount,
+                            sd.salary_structure,
+                        )
                     salary_slip_total -= sd.amount
 
         total_loan_repayment = self.process_loan_repayments_for_bank_entry(salary_details) or 0
         salary_slip_total -= total_loan_repayment
 
+        # ---- 1. Main consolidated bank entry for regular salary ----
         bank_entry = None
         if salary_slip_total != 0:
             remark = "withheld salaries" if for_withheld_salaries else "salaries"
             bank_entry = self.set_accounting_entries_for_bank_entry(
- 		   salary_slip_total, remark, employee_wise_accounting_enabled
-	    )
+                salary_slip_total, remark, employee_wise_accounting_enabled
+            )
             if for_withheld_salaries:
                 link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
-
-        else:
+        elif not flex_benefit_claims:
             frappe.msgprint(_("Total Net Pay is zero; Bank Entry will not be created."))
+
+        # ---- 2. One consolidated JE per flex-benefit component ----
+        # Each component gets its own JE so multi-component runs stay
+        # readable in the GL. Within each JE, every claimant is a separate
+        # party-tagged debit row when employee-wise accounting is enabled.
+        for component, claimants in flex_benefit_claims.items():
+            saved_entries = self.employee_based_payroll_payable_entries
+            component_total = sum(amount for _emp, amount, _ss in claimants)
+
+            if employee_wise_accounting_enabled:
+                self.employee_based_payroll_payable_entries = {
+                    employee: {
+                        "earnings": amount,
+                        "deductions": 0,
+                        "total_loan_repayment": 0,
+                        "salary_structure": salary_structure,
+                    }
+                    for employee, amount, salary_structure in claimants
+                }
+            else:
+                self.employee_based_payroll_payable_entries = {}
+
+            try:
+                self.set_accounting_entries_for_bank_entry(
+                    component_total,
+                    component,
+                    employee_wise_accounting_enabled,
+                )
+            finally:
+                self.employee_based_payroll_payable_entries = saved_entries
 
         return bank_entry


### PR DESCRIPTION
Two bugs in CustomPayrollEntry.make_bank_entry:

1. set_accounting_entries_for_bank_entry() requires employee_wise_accounting_enabled as a positional argument in HRMS 15.59.0+. Both call sites in this override pass only 2 args, causing TypeError on Make Bank Entry.

2. The upstream helper has been refactored to materialise a Journal Entry on each call and to iterate self.employee_based_payroll_payable_entries for employee-wise debit lines. Calling it inside the earnings loop for each flex-benefit-separate-JE row causes the dict — already populated by earlier regular-earnings rows — to be emitted into every flex-benefit JE, producing escalating, double-counted JEs.

Fix: collect flex-benefit-separate-JE rows in a per-component accumulator during the loop, then emit one consolidated JE per component after the main bank entry, with the dict scoped to only the claimants of that component.

Result for a payroll with N employees claiming 1 flex-benefit component (typical Nepal Festival Allowance scenario):
  Before: N+1 escalating JEs, totals don't reconcile
  After:  2 JEs (1 main salary + 1 component JE with N party-tagged rows)

For payrolls with M flex-benefit components:
  After: M+1 clean JEs

Reproduces against HRMS 15.59.0. Verified on Payroll Entry HR-PRUN-2026-00003 (Asoj 2082) with 7 Festival Allowance Benefit Claims: produces 1 Festival Allowance JE with 7 party-tagged rows and 1 consolidated salary JE; totals reconcile against sum of net pays.

### Proposed change
<!--
Please explain what changed and why it was necessary.

_Add screenshots or GIFs if applicable._
-->

---

### Breaking change
Does this PR introduce any breaking change?
- [ ] ❌ Yes (describe impact below)
- [x] ✅ No
- [ ] 🫤 Unsure (needs review)
<!--
_If **yes**, explain the impact and necessary migration steps:_
-->

---

### Type of change
What type of change does this PR introduce?
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)
- [ ] ⚡️ Feature (`MINOR v0.x.0`)
- [ ] 📚 Docs Update
- [ ] 🎨 Style/UI Change
- [ ] 🔄 Refactoring
- [ ] 🚀 Performance
- [ ] ✅ Testing
- [ ] ⚙️ CI/CD Build
- [ ] 📝 Other (add your own)

---

### PR Checklist
<!--
Before submitting, please ensure that the PR meets the following checklist:
_Put an `x` in the boxes that apply._
-->

- [ ] 📖 Updated documentation as required.
- [x] ✅ All local tests passed with my changes.
- [ ] 🔍 Checked for duplicate PRs with similar changes.
- [ ] 📝 Followed the [Contributing Guide](https://github.com/yarsa/nepal-compliance/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/yarsa/nepal-compliance/blob/master/CODE_OF_CONDUCT.md).

---

### Related Issues/ PRs
<!-- 
If this PR fixes a bug or relates to another PR, link them below:
-->
- **Fixes** #123 (auto-close when merged)
- **Related to** #456 (reference for context)
