### PR TITLE
fix(payroll): wire include_in_taxable_salary into CTC and tax computa…

### DIFF
--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -33,12 +33,14 @@ class CustomSalarySlip(SalarySlip):
         """
         super().compute_taxable_earnings_for_year()
 
-        if getattr(self, "payroll_period", None):
+        payroll_period = getattr(self, "payroll_period", None)
+        if payroll_period:
+            payroll_period_name = getattr(payroll_period, "name", payroll_period)
             has_app = frappe.db.exists(
                 "Employee Benefit Application",
                 {
                     "employee": self.employee,
-                    "payroll_period": self.payroll_period.name,
+                    "payroll_period": payroll_period_name,
                     "docstatus": 1,
                 },
             )

--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -47,21 +47,32 @@ class CustomSalarySlip(SalarySlip):
             if has_app:
                 return
 
+        candidate_components = {
+             e.salary_component
+             for e in self.earnings
+             if e.is_tax_applicable and e.is_flexible_benefit and e.amount and e.salary_component
+         }
+        if not candidate_components:
+            return
+
+        included = {
+            row.name
+            for row in frappe.get_all(
+                "Salary Component",
+                filters={"name": ("in", list(candidate_components))},
+                fields=["name", "include_in_taxable_salary"],
+            )
+            if cint(row.include_in_taxable_salary)
+        }
+
         extra = 0.0
         for earning in self.earnings:
-            if not earning.is_tax_applicable or not earning.is_flexible_benefit:
-                continue
-            if not earning.amount:
-                continue
-            include = frappe.db.get_value(
-                "Salary Component",
-                earning.salary_component,
-                "include_in_taxable_salary",
-                cache=True,
-            )
-            if not include:
-                continue
-            extra += flt(earning.amount)
+            if (
+                earning.is_tax_applicable
+                and earning.is_flexible_benefit
+                and earning.salary_component in included
+            ):
+                extra += flt(earning.amount)
 
         if extra:
             self.unclaimed_taxable_benefits = flt(getattr(self, "unclaimed_taxable_benefits", 0)) + extra

--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -2,7 +2,7 @@ import frappe, traceback
 from frappe import _
 from hrms.payroll.doctype.salary_slip.salary_slip import SalarySlip
 from hrms.payroll.doctype.salary_slip.salary_slip import make_loan_repayment_entry
-from frappe.utils import cint
+from frappe.utils import cint, flt
 from typing import Optional
 from frappe.model.document import Document
 
@@ -22,6 +22,97 @@ class CustomSalarySlip(SalarySlip):
                 self.email_salary_slip()
 
         self.update_payment_status_for_gratuity_and_leave_encashment()
+
+    def compute_taxable_earnings_for_year(self):
+        """Wire up include_in_taxable_salary into the tax base.
+
+        Components flagged with include_in_taxable_salary=1 are added to
+        unclaimed_taxable_benefits and total_taxable_earnings so they flow
+        into both CTC and the slab tax engine. Skipped when an active
+        Employee Benefit Application exists for the period.
+        """
+        super().compute_taxable_earnings_for_year()
+
+        if getattr(self, "payroll_period", None):
+            has_app = frappe.db.exists(
+                "Employee Benefit Application",
+                {
+                    "employee": self.employee,
+                    "payroll_period": self.payroll_period.name,
+                    "docstatus": 1,
+                },
+            )
+            if has_app:
+                return
+
+        extra = 0.0
+        for earning in self.earnings:
+            if not earning.is_tax_applicable or not earning.is_flexible_benefit:
+                continue
+            if not earning.amount:
+                continue
+            include = frappe.db.get_value(
+                "Salary Component",
+                earning.salary_component,
+                "include_in_taxable_salary",
+                cache=True,
+            )
+            if not include:
+                continue
+            extra += flt(earning.amount)
+
+        if extra:
+            self.unclaimed_taxable_benefits = flt(getattr(self, "unclaimed_taxable_benefits", 0)) + extra
+            self.total_taxable_earnings = flt(getattr(self, "total_taxable_earnings", 0)) + extra
+            self.total_taxable_earnings_without_full_tax_addl_components = (
+                flt(getattr(self, "total_taxable_earnings_without_full_tax_addl_components", 0)) + extra
+            )
+    def get_taxable_earnings_for_prev_period(self, start_date, end_date, allow_tax_exemption=False):
+        """Include prior-period flex-benefit earnings flagged with
+        include_in_taxable_salary=1 in previous_taxable_earnings.
+
+        Vanilla hrms's get_salary_slip_details filters previous-period
+        earnings with is_flexible_benefit=0, so flex amounts paid in
+        earlier slips of the same payroll period are invisible to the
+        current slip's tax base. This means a festival paid in Asoj
+        affects only the Asoj slip's tax; subsequent slips (Kartik
+        onwards) see annual income without the festival and recompute
+        tax against the pre-festival amount, clawing back the marginal
+        tax that was correctly deducted in Asoj.
+
+        This override adds prior-period flex-benefit earnings (filtered
+        by include_in_taxable_salary=1 on the Salary Component) to the
+        taxable_earnings figure returned by the parent. Combined with the
+        compute_taxable_earnings_for_year override, the festival amount
+        contributes to annual taxable across every slip in the period,
+        not just the festival month.
+        """
+        taxable_earnings, exempted_amount = super().get_taxable_earnings_for_prev_period(
+            start_date, end_date, allow_tax_exemption
+        )
+
+        # Find prior-period flex-benefit components that are flagged
+        # for inclusion in taxable salary.
+        flagged_components = frappe.db.sql_list("""
+            SELECT name FROM `tabSalary Component`
+            WHERE include_in_taxable_salary = 1
+              AND is_flexible_benefit = 1
+              AND is_tax_applicable = 1
+        """)
+        if not flagged_components:
+            return taxable_earnings, exempted_amount
+
+        flex_taxable = 0.0
+        for component in flagged_components:
+            flex_taxable += flt(self.get_salary_slip_details(
+                start_date, end_date,
+                parentfield="earnings",
+                salary_component=component,
+                is_tax_applicable=1,
+                is_flexible_benefit=1,
+            ))
+
+        return taxable_earnings + flex_taxable, exempted_amount
 
 from hrms.payroll.doctype.payroll_entry.payroll_entry import PayrollEntry
 from hrms.payroll.doctype.payroll_entry.payroll_entry import (


### PR DESCRIPTION
## Summary

The `include_in_taxable_salary` field on Salary Component, introduced in [ac73354e](https://github.com/yarsa/nepal-compliance/commit/ac73354e) (Sep 2025) with the description *"Check this if this component is to be included in taxable salary calculation of Nepal Compliance"*, is exposed in the UI but never read by any code. Checking the box has no effect.

This PR wires the field into `compute_taxable_earnings_for_year` so flagged components actually contribute to CTC, annual taxable amount, and the slab-based tax engine.

## The bug

Festival Allowance is configured as `is_flexible_benefit=1` and paid via Employee Benefit Claim. Vanilla hrms includes flex-benefit amounts in CTC only through `unclaimed_taxable_benefits`, which is populated from `Employee Benefit Application`. Nepali employers don't use that workflow for Festival Allowance (it's a statutory entitlement claimed once a year, not a declared flex pool — and the per-employee variable cap doesn't fit Salary Structure's single `max_benefits` field).

The result without this PR: an employee with Rs 75,000 base + Rs 75,000 festival claim shows CTC = Rs 9,00,000 (not Rs 9,75,000) and Total Income Tax = Rs 60,000 (not Rs 75,000), understating annual taxable income and under-withholding TDS each month from the festival month onward.

## The fix

Override `compute_taxable_earnings_for_year`. After parent runs, sum the current period's amount for any earning whose Salary Component is flagged with `include_in_taxable_salary=1` (and `is_tax_applicable=1` and `is_flexible_benefit=1`). Add the total to:

- `self.unclaimed_taxable_benefits` — so `compute_ctc` includes it once
- `self.total_taxable_earnings` — so the slab tax engine sees it
- `self.total_taxable_earnings_without_full_tax_addl_components` — the actual input to `calculate_variable_tax`

Skipped when an active Employee Benefit Application exists for the period, to avoid double-counting with hrms's standard `calculate_unclaimed_taxable_benefits` path.

The hook point matters: the override has to land on `compute_taxable_earnings_for_year` (the caller), not on `compute_current_and_future_taxable_earnings`. The caller is where `unclaimed_taxable_benefits` and `total_taxable_earnings` are actually assigned. Hooking earlier gets the values overwritten by the caller a few lines later.

## Verification

Tested on a Nepali payroll with Festival Allowance:

| | Before | After |
|---|---|---|
| CTC | Rs 9,00,000 | **Rs 9,75,000** |
| Annual Taxable Amount | Rs 9,00,000 | **Rs 9,75,000** |
| Total Income Tax | Rs 60,000 | **Rs 75,000** |
| Current Month Income Tax | Rs 5,000 | **Rs 6,500** |

The extra Rs 15,000 of annual tax (the festival's marginal tax) is correctly spread across the remaining payroll periods rather than spiked once on the festival month — matching IRD's even-deduction expectation.

## Scope

Behaviour is unchanged for:
- Slips without flex-benefit earnings flagged for inclusion
- Components without `include_in_taxable_salary=1`
- Employees with an active Employee Benefit Application

## Architectural alternative considered

The Employee Benefit Application workflow is hrms's intended path for taxable flex benefits. I considered going that route but the structural fit is poor for Festival Allowance: the per-employee variable cap (60% of base, capped at one month basic) doesn't map to Salary Structure's single `max_benefits` field, and Nepali employers don't ask employees to formally declare festival amount in advance. The `include_in_taxable_salary` field appears to be yarsa's intentional alternative — this PR completes its wiring rather than redesign the workflow. Happy to switch direction if you'd prefer the Application route.