### PR TITLE
Update large-pr-labeler.yml with permissions

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  issues: write
+  pull-requests: read
+
 jobs:
   label-large-pr:
     runs-on: ubuntu-slim

--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   label-large-pr:


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/large-pr-labeler.yml` to add explicit permissions required for the workflow to function properly.

Workflow permissions update:

* Added `issues: write` and `pull-requests: read` permissions to ensure the workflow can label pull requests and interact with issues as needed.