### PR TITLE
Fix accounting entries handling with employee-wise accounting flag

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  issues: write
+  pull-requests: read
+
 jobs:
   label-large-pr:
     runs-on: ubuntu-slim

--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   label-large-pr:

--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -167,8 +167,9 @@ class CustomPayrollEntry(PayrollEntry):
         bank_entry = None
         if salary_slip_total != 0:
             remark = "withheld salaries" if for_withheld_salaries else "salaries"
-            bank_entry = self.set_accounting_entries_for_bank_entry(salary_slip_total, remark)
-
+            bank_entry = self.set_accounting_entries_for_bank_entry(
+ 		   salary_slip_total, remark, employee_wise_accounting_enabled
+	    )
             if for_withheld_salaries:
                 link_bank_entry_in_salary_withholdings(salary_details, bank_entry.name)
 


### PR DESCRIPTION
This pull request introduces a permissions update to the GitHub Actions workflow and modifies the way bank entries are created for salary slips in the codebase. The main changes are grouped below:

**CI/CD Workflow Permissions:**

* Added explicit `issues: write` and `pull-requests: write` permissions to the `.github/workflows/large-pr-labeler.yml` workflow to ensure the workflow has the necessary access for labeling pull requests.

First time contribution by @anup-dh 
**Salary Slip Bank Entry Logic:**

* Updated the `make_bank_entry` method in `salary_slip.py` to pass `employee_wise_accounting_enabled` as an argument to `set_accounting_entries_for_bank_entry`, allowing for more granular control over accounting entries based on employee-wise settings.