### PR TITLE
Add write permissions for workflow contents

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by adjusting permissions in the `.github/workflows/large-pr-labeler.yml` file.

- Increased the `contents` permission from its previous value (default or none) to `write` in the workflow configuration.