### PR TITLE
Add write permissions for workflow contents

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by adjusting permissions.

- Permissions update:
  * [`.github/workflows/large-pr-labeler.yml`](diffhunk://#diff-067c723457d9e94633e64cdf590b63b617d96532b5a27e6d845956da299e7feeR8): Added `contents: write` permission to the workflow permissions block to ensure the workflow has the necessary access.