### PR TITLE
Update workflow to use pull_request_target event trigger

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -1,11 +1,11 @@
 name: Label Large PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for labeling large pull requests. The main changes involve improving security by switching the workflow trigger and adjusting repository permissions.

Workflow trigger and permissions updates:

* Changed the workflow trigger from `pull_request` to `pull_request_target` to allow the workflow to run with write permissions on pull requests from forks.
* Reduced the `contents` permission from `write` to `read` to follow the principle of least privilege and improve security.