### PR TITLE
Update workflow to use pull_request_target event trigger

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -1,11 +1,11 @@
 name: Label Large PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
This pull request updates the workflow configuration for labeling large pull requests. The main change is to use the `pull_request_target` event instead of `pull_request`, and to reduce the `contents` permission from `write` to `read`.

Workflow configuration updates:

* [`.github/workflows/large-pr-labeler.yml`](diffhunk://#diff-067c723457d9e94633e64cdf590b63b617d96532b5a27e6d845956da299e7feeL4-R8): Changed the workflow trigger from `pull_request` to `pull_request_target` for improved security and access to secrets, and reduced the `contents` permission from `write` to `read` to follow the principle of least privilege.