### PR TITLE
Simplify handling of large-pr label

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -65,20 +65,5 @@ jobs:
               });
               console.log('Label "large-pr" added.');
             } else {
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                owner,
-                repo,
-                issue_number: prNumber,
-              });
-              if (labels.some(label => label.name === 'large-pr')) {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  name: 'large-pr',
-                });
-                console.log('Label "large-pr" removed.');
-              } else {
-                console.log('Label "large-pr" not present, nothing to remove.');
-              }
+              console.log('Label "large-pr" not present, nothing to remove.');
             }


### PR DESCRIPTION
This pull request simplifies the logic for handling the removal of the "large-pr" label in the `.github/workflows/large-pr-labeler.yml` workflow. The code that checked for the label's presence and removed it if found has been removed, and now the workflow simply logs a message if the label is not present.

Label management simplification:

* Removed the logic that checked for and removed the "large-pr" label from pull requests, leaving only a log statement when the label is not present.