### PR TITLE
fix(sales): populate and sync nepali_date field in Sales Order/Invoice, guard against bs_date()

### DIFF
--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -61,6 +61,7 @@ doctype_js = {
     "Company": "public/js/validate.js",
     "Purchase Invoice": "public/js/purchase_invoice.js",
     "Sales Invoice": "public/js/sales_invoice.js",
+    "Sales Order": "public/js/sales_order.js",
     "CBMS Settings": "nepal_compliance/doctype/cbms_settings/cbms_settings.js",
     "Supplier": "public/js/validate.js",
     "Customer": "public/js/validate.js",
@@ -163,7 +164,8 @@ override_doctype_class = {
     "Employee Benefit Claim": "nepal_compliance.overrides.employee_benefit_claim.CustomEmployeeBenefitClaim",
     "Salary Slip": "nepal_compliance.overrides.salary_slip.CustomSalarySlip",
     "Payroll Entry": "nepal_compliance.overrides.salary_slip.CustomPayrollEntry",
-    "Leave Policy Assignment": "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.LeavePolicyAssignment"
+    "Leave Policy Assignment": "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.LeavePolicyAssignment",
+    "Item": "nepal_compliance.overrides.item.CustomItem"
 }
 
 # Document Events
@@ -181,9 +183,12 @@ doc_events = {
     },
     "Sales Invoice" : {
         "autoname": "nepal_compliance.utils.custom_autoname",
-        "before_insert": ["nepal_compliance.utils.set_vat_numbers", "nepal_compliance.utils.load_nepali_date"],
+        "before_insert": "nepal_compliance.utils.set_vat_numbers",
         "on_submit": "nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms",
-        "validate": "nepal_compliance.qr_code.create_qr_code"
+        "validate": ["nepal_compliance.qr_code.create_qr_code", "nepal_compliance.utils.load_nepali_date"]
+    },
+    "Sales Order" : {
+        "validate": "nepal_compliance.utils.load_nepali_date"
     },
     "Salary Slip": {
         "after_insert": "nepal_compliance.patches.payroll_entry.execute",

--- a/nepal_compliance/overrides/item.py
+++ b/nepal_compliance/overrides/item.py
@@ -1,0 +1,5 @@
+from erpnext.stock.doctype.item.item import Item
+
+
+class CustomItem(Item):
+    pass

--- a/nepal_compliance/public/js/sales_invoice.js
+++ b/nepal_compliance/public/js/sales_invoice.js
@@ -9,6 +9,14 @@ frappe.require([
             if (typeof handle_send_email === "function") {
                 handle_send_email(frm, "Sales Invoice");
             }
+            sync_nepali_date(frm, "posting_date");
+            attach_bs_picker(frm, "posting_date");
+        },
+        posting_date(frm) {
+            sync_nepali_date(frm, "posting_date");
+        },
+        nepali_date(frm) {
+            sync_ad_date(frm, "posting_date");
         },
         on_submit(frm) {
             frappe.call({
@@ -69,3 +77,82 @@ frappe.require([
         }
     });
 });
+
+// Keep the BS "Nepali Date" field in sync with the AD date field both ways.
+function sync_nepali_date(frm, ad_field) {
+    if (typeof NepaliFunctions === "undefined") return;
+    const ad_value = frm.doc[ad_field];
+    if (!ad_value) return;
+
+    const bs = NepaliFunctions.AD2BS(ad_value);
+    if (bs && frm.doc.nepali_date !== bs) {
+        frm.set_value("nepali_date", bs);
+    }
+}
+
+function sync_ad_date(frm, ad_field) {
+    if (typeof NepaliFunctions === "undefined") return;
+    if (!frm.doc.nepali_date) return;
+
+    const ad = NepaliFunctions.BS2AD(frm.doc.nepali_date);
+    if (ad && frm.doc[ad_field] !== ad) {
+        frm.set_value(ad_field, ad);
+    }
+}
+
+// Open a BS calendar popover when the user clicks the "Nepali Date" field,
+// so it can be set manually with a picker (not just typed).
+function attach_bs_picker(frm, ad_field) {
+    if (typeof NepaliCalendarLib === "undefined" || typeof NepaliFunctions === "undefined") return;
+
+    const field = frm.get_field("nepali_date");
+    if (!field || !field.$input || field._bs_picker_attached) return;
+    field._bs_picker_attached = true;
+
+    field.$input.on("focus", () => open_bs_popover(frm, field, ad_field));
+}
+
+function open_bs_popover(frm, field, ad_field) {
+    if (field._popover || !field.$input) return;
+
+    const rect = field.$input[0].getBoundingClientRect();
+    const pop = document.createElement("div");
+    pop.classList.add("nepali-calendar-popover");
+    Object.assign(pop.style, {
+        position: "absolute",
+        top: rect.bottom + window.scrollY + "px",
+        left: rect.left + window.scrollX + "px",
+        zIndex: 99999,
+    });
+    document.body.appendChild(pop);
+    field._popover = pop;
+
+    const close = () => {
+        NepaliCalendarLib.unmount?.(pop);
+        pop.remove();
+        field._popover = null;
+        document.removeEventListener("mousedown", outside);
+    };
+    const outside = (e) => {
+        if (!pop.contains(e.target) && e.target !== field.$input[0]) close();
+    };
+    document.addEventListener("mousedown", outside);
+
+    let selectedBS;
+    if (frm.doc.nepali_date) {
+        const ad = NepaliFunctions.BS2AD(frm.doc.nepali_date);
+        if (ad) selectedBS = NepaliFunctions.AD2BS(ad, false);
+    } else if (frm.doc[ad_field]) {
+        selectedBS = NepaliFunctions.AD2BS(frm.doc[ad_field], false);
+    }
+
+    NepaliCalendarLib.render(pop, {
+        selectedDateBS: selectedBS,
+        onSelect: (selected) => {
+            const adDate = selected.format({ format: "YYYY-MM-DD", calendar: "AD" });
+            frm.set_value(ad_field, adDate);
+            frm.set_value("nepali_date", NepaliFunctions.AD2BS(adDate, true));
+            close();
+        }
+    });
+}

--- a/nepal_compliance/public/js/sales_order.js
+++ b/nepal_compliance/public/js/sales_order.js
@@ -1,0 +1,91 @@
+frappe.ui.form.on("Sales Order", {
+    refresh(frm) {
+        sync_nepali_date(frm, "transaction_date");
+        attach_bs_picker(frm, "transaction_date");
+    },
+    transaction_date(frm) {
+        sync_nepali_date(frm, "transaction_date");
+    },
+    nepali_date(frm) {
+        sync_ad_date(frm, "transaction_date");
+    }
+});
+
+// Keep the BS "Nepali Date" field in sync with the AD date field both ways.
+function sync_nepali_date(frm, ad_field) {
+    if (typeof NepaliFunctions === "undefined") return;
+    const ad_value = frm.doc[ad_field];
+    if (!ad_value) return;
+
+    const bs = NepaliFunctions.AD2BS(ad_value);
+    if (bs && frm.doc.nepali_date !== bs) {
+        frm.set_value("nepali_date", bs);
+    }
+}
+
+function sync_ad_date(frm, ad_field) {
+    if (typeof NepaliFunctions === "undefined") return;
+    if (!frm.doc.nepali_date) return;
+
+    const ad = NepaliFunctions.BS2AD(frm.doc.nepali_date);
+    if (ad && frm.doc[ad_field] !== ad) {
+        frm.set_value(ad_field, ad);
+    }
+}
+
+// Open a BS calendar popover when the user clicks the "Nepali Date" field,
+// so it can be set manually with a picker (not just typed).
+function attach_bs_picker(frm, ad_field) {
+    if (typeof NepaliCalendarLib === "undefined" || typeof NepaliFunctions === "undefined") return;
+
+    const field = frm.get_field("nepali_date");
+    if (!field || !field.$input || field._bs_picker_attached) return;
+    field._bs_picker_attached = true;
+
+    field.$input.on("focus", () => open_bs_popover(frm, field, ad_field));
+}
+
+function open_bs_popover(frm, field, ad_field) {
+    if (field._popover || !field.$input) return;
+
+    const rect = field.$input[0].getBoundingClientRect();
+    const pop = document.createElement("div");
+    pop.classList.add("nepali-calendar-popover");
+    Object.assign(pop.style, {
+        position: "absolute",
+        top: rect.bottom + window.scrollY + "px",
+        left: rect.left + window.scrollX + "px",
+        zIndex: 99999,
+    });
+    document.body.appendChild(pop);
+    field._popover = pop;
+
+    const close = () => {
+        NepaliCalendarLib.unmount?.(pop);
+        pop.remove();
+        field._popover = null;
+        document.removeEventListener("mousedown", outside);
+    };
+    const outside = (e) => {
+        if (!pop.contains(e.target) && e.target !== field.$input[0]) close();
+    };
+    document.addEventListener("mousedown", outside);
+
+    let selectedBS;
+    if (frm.doc.nepali_date) {
+        const ad = NepaliFunctions.BS2AD(frm.doc.nepali_date);
+        if (ad) selectedBS = NepaliFunctions.AD2BS(ad, false);
+    } else if (frm.doc[ad_field]) {
+        selectedBS = NepaliFunctions.AD2BS(frm.doc[ad_field], false);
+    }
+
+    NepaliCalendarLib.render(pop, {
+        selectedDateBS: selectedBS,
+        onSelect: (selected) => {
+            const adDate = selected.format({ format: "YYYY-MM-DD", calendar: "AD" });
+            frm.set_value(ad_field, adDate);
+            frm.set_value("nepali_date", NepaliFunctions.AD2BS(adDate, true));
+            close();
+        }
+    });
+}

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -101,7 +101,9 @@ def load_nepali_date(doc, method):
         return
 
     bs = bs_date(ad_value)
-    if bs:
+    # bs_date() returns the input unchanged when conversion is skipped or fails;
+    # only store the result when it actually differs from the AD value.
+    if bs and str(bs).strip() != str(ad_value).strip():
         doc.nepali_date = str(bs).strip()
 
 def bill_no_required(doc, method):

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -81,14 +81,28 @@ def set_vat_numbers(doc, method):
                     doc.supplier_vat_number = company_vat
 
 def load_nepali_date(doc, method):
-    if not hasattr(doc, "nepali_date") or not hasattr(doc, "posting_date"):
+    if not hasattr(doc, "nepali_date"):
         return
 
-    posting_date_str = str(doc.posting_date).strip()
-    nepali_date_str = str(doc.nepali_date).strip() if doc.nepali_date else ""
+    ad_field = "posting_date" if hasattr(doc, "posting_date") else (
+        "transaction_date" if hasattr(doc, "transaction_date") else None
+    )
+    if not ad_field:
+        return
 
-    if nepali_date_str and posting_date_str != nepali_date_str:
+    ad_value = doc.get(ad_field)
+    if not ad_value:
         doc.nepali_date = None
+        return
+
+    from nepal_compliance.nepali_date_utils.utils import bs_date, nepal_compliance_enabled
+
+    if not nepal_compliance_enabled():
+        return
+
+    bs = bs_date(ad_value)
+    if bs:
+        doc.nepali_date = str(bs).strip()
 
 def bill_no_required(doc, method):
     if doc.doctype != "Purchase Invoice":


### PR DESCRIPTION
The nepali_date Data field never worked in the UI. load_nepali_date
compared a BS string to an AD string (which never match) and nulled the
field on every insert, and no client handler populated it.

- Rewrite load_nepali_date to compute BS from posting_date/transaction_date
  via bs_date(), guarded by the enable_nepali_date setting
- Move the hook from before_insert to validate so it recomputes on date change;
  add the same hook for Sales Order
- Add two-way client sync (AD <-> BS) on Sales Invoice and a new sales_order.js
- Attach a NepaliCalendarLib popover so the field is pickable
- Merge the Item entry into the single override_doctype_class dict
- Add the missing nepal_compliance/overrides/item.py (CustomItem)

Fixes #272 