### PR TITLE
fix: Label Large PR workflow failed for forked PRs (#265)

### DIFF
--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -2,8 +2,9 @@ name: Label Large PR
 
 on:
   pull_request:
-permissions:
     types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
+
 
 permissions:
   pull-requests: write

--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -2,6 +2,8 @@ name: Label Large PR
 
 on:
   pull_request:
+permissions:
+  pull-requests: write
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -3,7 +3,6 @@ name: Label Large PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    types: [opened, synchronize, reopened]
 
 
 permissions:

--- a/.github/workflows/large-pr-labeler.yml
+++ b/.github/workflows/large-pr-labeler.yml
@@ -3,8 +3,10 @@ name: Label Large PR
 on:
   pull_request:
 permissions:
-  pull-requests: write
     types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
 
 jobs:
   label-large-pr:


### PR DESCRIPTION
Adds `pull-requests: write` permission to the workflow, which should resolve the HTTP 403 error when adding/removing labels on PRs from forks.\n\nCloses #265.