### PR TITLE
fix(ci): make Docker build install all apps (multi-line apps.json + schema check)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -73,10 +73,12 @@ jobs:
       - name: Validate APPS_JSON and write apps.json
         run: |
           test -n "$APPS_JSON" || { echo "::error::APPS_JSON repository variable is empty"; exit 1; }
-          printf '%s' "$APPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null \
-            || { echo "::error::APPS_JSON must be a non-empty JSON array"; exit 1; }
+          printf '%s' "$APPS_JSON" \
+            | jq -e 'type == "array" and length > 0 and all(.[]; (.url | type == "string" and (length > 0)) and (.branch | type == "string" and (length > 0)))' >/dev/null \
+            || { echo "::error::APPS_JSON must be a non-empty JSON array of {\"url\", \"branch\"} string entries"; exit 1; }
           printf '%s' "$APPS_JSON" > "$GITHUB_WORKSPACE/apps.json"
-          echo "APPS_JSON OK: $(jq -r 'map(.url) | join(", ")' "$GITHUB_WORKSPACE/apps.json")"
+          # Log only repo names + count — never the raw URLs, which may carry credentials.
+          echo "APPS_JSON OK: $(jq 'length' "$GITHUB_WORKSPACE/apps.json") apps: $(jq -r '[.[].url | sub("\\.git$"; "") | sub(".*/"; "")] | join(", ")' "$GITHUB_WORKSPACE/apps.json")"
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -70,12 +70,13 @@ jobs:
           git -C frappe_docker checkout --detach "${FRAPPE_DOCKER_REF}"
           git -C frappe_docker --no-pager log -1 --format='Pinned frappe_docker to %H %s'
 
-      - name: Validate APPS_JSON
+      - name: Validate APPS_JSON and write apps.json
         run: |
           test -n "$APPS_JSON" || { echo "::error::APPS_JSON repository variable is empty"; exit 1; }
           printf '%s' "$APPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null \
             || { echo "::error::APPS_JSON must be a non-empty JSON array"; exit 1; }
-          echo "APPS_JSON OK: $(printf '%s' "$APPS_JSON" | jq -r 'map(.url) | join(", ")')"
+          printf '%s' "$APPS_JSON" > "$GITHUB_WORKSPACE/apps.json"
+          echo "APPS_JSON OK: $(jq -r 'map(.url) | join(", ")' "$GITHUB_WORKSPACE/apps.json")"
 
       - name: Build and push by digest
         id: build
@@ -89,9 +90,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           # apps.json is passed as a BuildKit secret (id=apps_json) — the Containerfile
-          # mounts it at /opt/frappe/apps.json. Passing it as a build-arg no longer works.
-          secrets: |
-            apps_json=${{ env.APPS_JSON }}
+          # mounts it at /opt/frappe/apps.json. Use secret-files (not inline secrets)
+          # so the full multi-line JSON is preserved.
+          secret-files: |
+            apps_json=${{ github.workspace }}/apps.json
           build-args: |
             FRAPPE_PATH=https://github.com/frappe/frappe
             FRAPPE_BRANCH=version-15


### PR DESCRIPTION
## Changes
- **Pass apps.json via `secret-files`, not inline `secrets`.** Inline `secrets:` only captures the first line of a multi-line value, so `apps.json` arrived as just `[` and `bench init` died with `JSONDecodeError`. Writing the JSON to a file and passing it with `secret-files` preserves the full content.
- **Harden `APPS_JSON` validation.** Now requires a non-empty array where every entry has non-empty string `url` and `branch`, and the log prints only repo names + count (never raw URLs, which could carry credentials).