### PR TITLE
ci-test-runner.yml: Add CI Test Runner for Frappe v15 Tests and fix issues it raised

### DIFF
--- a/.github/workflows/ci-test-runner.yml
+++ b/.github/workflows/ci-test-runner.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Checkout nepal_compliance
         uses: actions/checkout@v4
         with:
-          # frappe alongside this, then we `bench get-app` from this local path
-          path: apps/nepal_compliance
+          path: src/nepal_compliance
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -86,7 +85,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('apps/nepal_compliance/pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('src/nepal_compliance/pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install system dependencies
@@ -136,7 +135,7 @@ jobs:
         run: |
           # Move the checked-out source into the bench's apps directory.
           mv "${GITHUB_WORKSPACE}/apps/nepal_compliance" apps/nepal_compliance
-          bench get-app nepal_compliance apps/nepal_compliance
+          bench get-app --soft-link nepal_compliance src/nepal_compliance
 
       - name: Create test site and install apps
         working-directory: frappe-bench

--- a/.github/workflows/ci-test-runner.yml
+++ b/.github/workflows/ci-test-runner.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - "**/*.md"
   pull_request:
+    branches: ["master", "develop"]
     paths-ignore:
       - "**/*.md"
 

--- a/.github/workflows/ci-test-runner.yml
+++ b/.github/workflows/ci-test-runner.yml
@@ -133,9 +133,7 @@ jobs:
       - name: Install nepal_compliance into bench
         working-directory: frappe-bench
         run: |
-          # Move the checked-out source into the bench's apps directory.
-          mv "${GITHUB_WORKSPACE}/apps/nepal_compliance" apps/nepal_compliance
-          bench get-app --soft-link nepal_compliance src/nepal_compliance
+          bench get-app --soft-link "${GITHUB_WORKSPACE}/src/nepal_compliance"
 
       - name: Create test site and install apps
         working-directory: frappe-bench

--- a/.github/workflows/ci-test-runner.yml
+++ b/.github/workflows/ci-test-runner.yml
@@ -150,6 +150,10 @@ jobs:
           bench --site test_site install-app nepal_compliance
           bench --site test_site set-config allow_tests true
 
+      - name: Install test dependencies
+        working-directory: frappe-bench
+        run: ./env/bin/pip install coverage
+
       - name: Run tests
         working-directory: frappe-bench
         run: bench --site test_site run-tests --app nepal_compliance --coverage

--- a/.github/workflows/ci-test-runner.yml
+++ b/.github/workflows/ci-test-runner.yml
@@ -1,0 +1,166 @@
+name: CI Test Runner
+
+on:
+  push:
+    branches: ["master", "develop"]
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+
+# cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# only read code
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Frappe Tests (v15)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    env:
+      # match versions used by Docker build
+      FRAPPE_BRANCH: version-15
+      ERPNEXT_BRANCH: version-15
+      HRMS_BRANCH: version-15
+      TZ: Asia/Kathmandu
+
+    services:
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+      redis-cache:
+        image: redis:6.2-alpine
+        ports:
+          - 13000:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+      redis-queue:
+        image: redis:6.2-alpine
+        ports:
+          - 11000:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout nepal_compliance
+        uses: actions/checkout@v4
+        with:
+          # frappe alongside this, then we `bench get-app` from this local path
+          path: apps/nepal_compliance
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('apps/nepal_compliance/pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libmysqlclient-dev mariadb-client redis-tools wkhtmltopdf
+          # yarn for building assets
+          sudo npm install -g yarn
+
+      - name: Configure MariaDB for Frappe
+        run: |
+          # Frappe requires utf8mb4 + a few server settings for tests to pass.
+          mysql -h 127.0.0.1 -P 3306 -u root -proot <<'SQL'
+          SET GLOBAL character_set_server = 'utf8mb4';
+          SET GLOBAL collation_server = 'utf8mb4_unicode_ci';
+          SQL
+
+      - name: Install bench
+        run: pip install frappe-bench
+
+      - name: Initialise bench
+        run: |
+          bench init \
+            --skip-redis-config-generation \
+            --frappe-branch "${FRAPPE_BRANCH}" \
+            --python "$(which python)" \
+            frappe-bench
+          # Point bench at the CI service containers.
+          cd frappe-bench
+          bench set-config -g redis_cache "redis://127.0.0.1:13000"
+          bench set-config -g redis_queue "redis://127.0.0.1:11000"
+          bench set-config -g redis_socketio "redis://127.0.0.1:11000"
+          bench set-config -g db_host 127.0.0.1
+          bench set-config -g db_port 3306
+
+      - name: Get dependent apps (erpnext, hrms)
+        working-directory: frappe-bench
+        run: |
+          # nepal_compliance's tests import from erpnext and hrms, so both must
+          # be present in the bench before we install this app.
+          bench get-app --branch "${ERPNEXT_BRANCH}" erpnext https://github.com/frappe/erpnext
+          bench get-app --branch "${HRMS_BRANCH}" hrms https://github.com/frappe/hrms
+
+      - name: Install nepal_compliance into bench
+        working-directory: frappe-bench
+        run: |
+          # Move the checked-out source into the bench's apps directory.
+          mv "${GITHUB_WORKSPACE}/apps/nepal_compliance" apps/nepal_compliance
+          bench get-app nepal_compliance apps/nepal_compliance
+
+      - name: Create test site and install apps
+        working-directory: frappe-bench
+        run: |
+          bench new-site test_site \
+            --mariadb-root-password root \
+            --admin-password admin \
+            --no-mariadb-socket \
+            --db-host 127.0.0.1 \
+            --db-port 3306
+          # Order matters: erpnext -> hrms -> nepal_compliance.
+          bench --site test_site install-app erpnext
+          bench --site test_site install-app hrms
+          bench --site test_site install-app nepal_compliance
+          bench --site test_site set-config allow_tests true
+
+      - name: Run tests
+        working-directory: frappe-bench
+        run: bench --site test_site run-tests --app nepal_compliance --coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: frappe-bench/sites/coverage.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/nepal_compliance/custom_code/payroll/test_income_tax_slab.py
+++ b/nepal_compliance/custom_code/payroll/test_income_tax_slab.py
@@ -1,6 +1,7 @@
 import frappe
+from unittest.mock import patch
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import today, add_years, add_days
+from frappe.utils import today, add_years, add_days, getdate
 from frappe import _
 import hashlib
 from erpnext.accounts.utils import get_fiscal_year
@@ -60,12 +61,15 @@ class TestIncomeTaxSlab(FrappeTestCase):
 
     # Test Cases
     def test_get_fiscal_year_for_company(self):
-        #Should return fiscal year document for company
-        fy = get_fiscal_year_for_company(self.company)
-        self.assertIsNotNone(fy)
-        self.assertTrue(
-            any(c.company == self.company for c in fy.companies)
-        )
+    # Should return the fiscal year applicable to the company for today.
+    fy = get_fiscal_year_for_company(self.company)
+    self.assertIsNotNone(fy)
+    # ERPNext FYs may be global (no company restriction) or company-specific;
+    # a global FY applies to every company, so accept either.
+    linked = [c.company for c in fy.companies]
+    self.assertTrue(not linked or self.company in linked)
+    self.assertLessEqual(getdate(fy.year_start_date), getdate(today()))
+    self.assertGreaterEqual(getdate(fy.year_end_date), getdate(today()))
 
     def test_create_income_tax_slab(self):
         #Should create income tax slab with correct slab count
@@ -108,7 +112,8 @@ class TestIncomeTaxSlab(FrappeTestCase):
         self.assertEqual(len(slab_doc.slabs), 5)
 
     def test_no_fiscal_year(self):
-        #Should return None when fiscal year does not exist
-        non_existing_company = "Invalid Company"
-        fy = get_fiscal_year_for_company(non_existing_company)
-        self.assertIsNone(fy)
+    with patch(
+        "nepal_compliance.custom_code.payroll.income_tax_slab.get_fiscal_year",
+        side_effect=frappe.exceptions.ValidationError,
+    ):
+        self.assertIsNone(get_fiscal_year_for_company("Any Company"))

--- a/nepal_compliance/custom_code/payroll/test_income_tax_slab.py
+++ b/nepal_compliance/custom_code/payroll/test_income_tax_slab.py
@@ -61,15 +61,12 @@ class TestIncomeTaxSlab(FrappeTestCase):
 
     # Test Cases
     def test_get_fiscal_year_for_company(self):
-    # Should return the fiscal year applicable to the company for today.
-    fy = get_fiscal_year_for_company(self.company)
-    self.assertIsNotNone(fy)
-    # ERPNext FYs may be global (no company restriction) or company-specific;
-    # a global FY applies to every company, so accept either.
-    linked = [c.company for c in fy.companies]
-    self.assertTrue(not linked or self.company in linked)
-    self.assertLessEqual(getdate(fy.year_start_date), getdate(today()))
-    self.assertGreaterEqual(getdate(fy.year_end_date), getdate(today()))
+        fy = get_fiscal_year_for_company(self.company)
+        self.assertIsNotNone(fy)
+        linked = [c.company for c in fy.companies]
+        self.assertTrue(not linked or self.company in linked)
+        self.assertLessEqual(getdate(fy.year_start_date), getdate(today()))
+        self.assertGreaterEqual(getdate(fy.year_end_date), getdate(today()))
 
     def test_create_income_tax_slab(self):
         #Should create income tax slab with correct slab count
@@ -112,8 +109,8 @@ class TestIncomeTaxSlab(FrappeTestCase):
         self.assertEqual(len(slab_doc.slabs), 5)
 
     def test_no_fiscal_year(self):
-    with patch(
-        "nepal_compliance.custom_code.payroll.income_tax_slab.get_fiscal_year",
-        side_effect=frappe.exceptions.ValidationError,
-    ):
-        self.assertIsNone(get_fiscal_year_for_company("Any Company"))
+        with patch(
+            "nepal_compliance.custom_code.payroll.income_tax_slab.get_fiscal_year",
+            side_effect=frappe.exceptions.ValidationError,
+        ):
+            self.assertIsNone(get_fiscal_year_for_company("Any Company"))

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -205,7 +205,7 @@ scheduler_events = {
 # Testing
 # -------
 
-# before_tests = "nepal_compliance.install.before_tests"
+before_tests = "nepal_compliance.install.before_tests"
 
 # Overriding Methods
 # ------------------------------

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -158,7 +158,8 @@ before_uninstall = "nepal_compliance.uninstall.cleanup_salary_structures"
 # DocType Class
 # ---------------
 # Override standard doctype classes
-override_doctype_class = {
+# `extend_doctype_class` does not exist in v15. `override_doctype_class` is only available mechanism
+override_doctype_class = {  # nosemgrep: frappe-semgrep-rules.rules.override-doctype-class
     "Sales Invoice": "nepal_compliance.overrides.custom_sales_invoice.CustomSalesInvoice",
     "Salary Structure": "nepal_compliance.overrides.salary_structure.CustomSalaryStructure",
     "Employee Benefit Claim": "nepal_compliance.overrides.employee_benefit_claim.CustomEmployeeBenefitClaim",

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -166,7 +166,6 @@ override_doctype_class = {  # nosemgrep: frappe-semgrep-rules.rules.override-doc
     "Salary Slip": "nepal_compliance.overrides.salary_slip.CustomSalarySlip",
     "Payroll Entry": "nepal_compliance.overrides.salary_slip.CustomPayrollEntry",
     "Leave Policy Assignment": "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.LeavePolicyAssignment",
-    "Item": "nepal_compliance.overrides.item.CustomItem"
 }
 
 # Document Events

--- a/nepal_compliance/install.py
+++ b/nepal_compliance/install.py
@@ -19,4 +19,3 @@ def before_tests():
     frappe.clear_cache()
     from erpnext.setup.utils import before_tests as erpnext_before_tests
     erpnext_before_tests()
-    frappe.db.commit()

--- a/nepal_compliance/install.py
+++ b/nepal_compliance/install.py
@@ -14,3 +14,9 @@ def install():
     modify_email_salary_slip_default()
     setup_default_leave_types()
     print_cancelled_invoice()
+
+def before_tests():
+    frappe.clear_cache()
+    from erpnext.setup.utils import before_tests as erpnext_before_tests
+    erpnext_before_tests()
+    frappe.db.commit()

--- a/nepal_compliance/overrides/item.py
+++ b/nepal_compliance/overrides/item.py
@@ -1,5 +1,0 @@
-from erpnext.stock.doctype.item.item import Item
-
-
-class CustomItem(Item):
-    pass

--- a/nepal_compliance/overrides/salary_slip.py
+++ b/nepal_compliance/overrides/salary_slip.py
@@ -43,6 +43,7 @@ class CustomPayrollEntry(PayrollEntry):
                 payroll_entry=self,
                 salary_slips=salary_slips,
                 publish_progress=False,
+                enqueue_after_commit=True,
                 )
             frappe.msgprint(
                 _("Salary Slip submission is queued. It may take a few minutes"),
@@ -177,3 +178,9 @@ class CustomPayrollEntry(PayrollEntry):
             frappe.msgprint(_("Total Net Pay is zero; Bank Entry will not be created."))
 
         return bank_entry
+
+
+def submit_salary_slips_for_employees(payroll_entry, salary_slips, publish_progress=False):
+    payroll_entry.submit_salary_slips_for_employees(
+        salary_slips, publish_progress=publish_progress
+    )


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the `nepal_compliance` test suite on every push/PR to `master`/`develop`. 

To bring CI working introduced other few real issues, which was fixed here too.

### CI
- New `ci-test-runner.yml`:
- MariaDB 10.6 + Redis (cache/queue) services,
- Frappe `v15` bench with erpnext + hrms,
- installs the `nepal_compliance` via `get-app --soft-link`,  runs `run-tests --coverage`, uploads `coverage.xml`.

### Test setup
- Enable the `before_tests` hook so ERPNext setup runs and tests get their master data
- Install `coverage` into the bench env (required by `--coverage`).

### Fixes raised by CI
- **Payroll:** add `enqueue_after_commit=True` and the missing module-level `submit_salary_slips_for_employees` wrapper, the queued (>30 slips) path previously raised `NameError`. — `overrides/salary_slip.py`
- **Income-tax-slab tests:** stop assuming an empty DB, accept a global *or* company-specific Fiscal Year, and exercise the real "no FY" path. `test_income_tax_slab.py`
- **Lint/cleanup:** keep `override_doctype_class` with a documented `# nosemgrep` because v15 has no `extend_doctype_class` and remove the dead `Item` override + `overrides/item.py`.