### PR TITLE
feat(calendar): current fiscal year jump + month/year quick select in Nepali datepicker

### DIFF
--- a/nepal_compliance/public/css/nepali_calendar.css
+++ b/nepal_compliance/public/css/nepali_calendar.css
@@ -1,1 +1,617 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");.nepali-calendar-popover{animation:fadeIn .12s ease-out;border-radius:.5rem;box-shadow:0 4px 10px 2px hsla(226,5%,51%,.18);overflow:hidden;width:max-content}.nepali-calendar-popover html[data-theme=dark],.nepali-calendar-popover[data-theme=dark],:root[data-theme=dark] .nepali-calendar-popover{border:1px solid hsla(0,0%,97%,.1);box-shadow:none}@keyframes fadeIn{0%{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}.calendar-wrapper{--color-background:#fff;--color-text:#040609;--color-text-secondary:#4a5565;--color-selected:#1c46ed;--color-selected-bg:rgba(28,70,237,.18);--color-holiday:#ec0b15;--color-hover:#f3f3f3;--color-click:#e7e7e7;--color-border:rgba(4,6,9,.06)}.calendar-wrapper html[data-theme=dark],.calendar-wrapper[data-theme=dark],:root[data-theme=dark] .calendar-wrapper{--color-background:#171717;--color-text:#f8f8f8;--color-text-secondary:#9c9c9c;--color-selected:#007be0;--color-selected-bg:rgba(0,123,224,.18);--color-holiday:#e02d2d;--color-hover:hsla(0,0%,97%,.06);--color-click:hsla(0,0%,97%,.2);--color-border:hsla(0,0%,97%,.1)}.calendar-wrapper *,.calendar-wrapper :after,.calendar-wrapper :before{border:0 solid;box-sizing:border-box;margin:0;padding:0}.calendar-wrapper h1,.calendar-wrapper h2,.calendar-wrapper h3,.calendar-wrapper h4,.calendar-wrapper h5,.calendar-wrapper h6{font-size:inherit;font-weight:inherit}.calendar-wrapper button{font-feature-settings:inherit;background-color:transparent;border-radius:0;color:inherit;font:inherit;font-variation-settings:inherit;letter-spacing:inherit;opacity:1}.calendar-wrapper button,.calendar-wrapper input:where([type=button],[type=reset],[type=submit]){appearance:button}.calendar-wrapper{background-color:var(--color-background);color:var(--color-text);font-family:Inter,sans-serif;font-optical-sizing:auto;font-style:normal;user-select:none;width:16rem}.calendar-wrapper .picker-action-bar{border-bottom:1px solid var(--color-border);font-size:.875rem;font-weight:500;padding:.25rem}.calendar-wrapper .picker-action-bar .back-button{align-items:center;border-radius:.375rem;display:flex;gap:.5rem;padding:.375rem .5rem;width:100%}.calendar-wrapper .picker-action-bar .back-button:hover{background-color:var(--color-hover)}.calendar-wrapper .picker-action-bar .back-button svg{stroke-width:2.5;height:1rem;width:1rem}.calendar-wrapper .content-scroll{max-height:16rem;overflow:auto}.calendar-wrapper .year-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));padding:.5rem}.calendar-wrapper .year-grid .year{cursor:pointer;font-size:1rem;padding:.5rem}.calendar-wrapper .year-grid .year.current{color:var(--color-selected)}.calendar-wrapper .year-grid .year:hover{background-color:var(--color-hover)}.calendar-wrapper .year-grid .year:active{background-color:var(--color-click)}.calendar-wrapper .month-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));padding:.5rem}.calendar-wrapper .month-grid .month{cursor:pointer;font-size:.75rem;padding:.5rem}.calendar-wrapper .month-grid .month:hover{background-color:var(--color-hover)}.calendar-wrapper .month-grid .month .np{font-weight:500}.calendar-wrapper .month-grid .month .ad{font-size:.6875rem;line-height:1.8;opacity:.8}.calendar-wrapper .month-grid .month.current{color:var(--color-selected)}.calendar-wrapper .month-grid .month:active{background-color:var(--color-click)}.calendar-wrapper .days-header .header-actions{align-items:center;display:flex;flex-direction:row}.calendar-wrapper .days-header .month-button{color:currentColor;cursor:pointer}.calendar-wrapper .days-header .month-button:not(:disabled):hover>*{background-color:var(--color-hover)}.calendar-wrapper .days-header .month-button:not(:disabled):active>*{background-color:var(--color-click)}.calendar-wrapper .days-header .month-button{padding:.25rem}.calendar-wrapper .days-header .month-button:disabled{cursor:not-allowed;opacity:.6}.calendar-wrapper .days-header .month-button .button-feedback{align-items:center;border-radius:.375rem;display:flex;font-size:1.25rem;height:2rem;justify-content:center;line-height:1.4;width:2rem}.calendar-wrapper .days-header .month-button .button-feedback svg{stroke-width:2.5;height:.8em;width:.8em}.calendar-wrapper .days-header .year-wrapper{flex:1}.calendar-wrapper .days-header .year-wrapper .year-button{align-items:center;cursor:pointer;display:flex;justify-content:center;margin:0 auto;padding:.25rem .75rem}.calendar-wrapper .days-header .year-wrapper .year-button .ad{font-size:.6875rem;opacity:.7;padding-inline:.25rem}.calendar-wrapper .days-header .year-wrapper .year-button:hover{background-color:var(--color-hover)}.calendar-wrapper .days-header .year-wrapper .year-button:active{background-color:var(--color-click)}.calendar-wrapper .days-header .year-wrapper .year-button{border-radius:.375rem;font-size:1rem;font-weight:500}.calendar-wrapper .days-header .year-wrapper .year-button svg{stroke-width:2;height:1rem;width:1rem}.calendar-wrapper .days-header .selected-month{align-items:center;display:flex;font-size:.68rem;font-weight:500;justify-content:space-between;padding:.25rem .5rem}.calendar-wrapper .week-days{border-block:1px solid var(--color-border);display:grid;font-size:.7rem;grid-template-columns:repeat(7,minmax(0,1fr));line-height:1.4286;text-align:center}.calendar-wrapper .week-days>:not(:last-child){border-inline-end:1px solid var(--color-background)}.calendar-wrapper .week-days .day{background-color:var(--color-background);padding:.25rem}.calendar-wrapper .week-days .day.holiday{color:var(--color-holiday)}.calendar-wrapper .days-grid{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));padding:.25rem;text-align:center}.calendar-wrapper .days-grid>:not(:last-child){border-bottom:1px solid var(--color-background);border-inline-end:1px solid var(--color-background)}.calendar-wrapper .days-grid .day{align-items:center;aspect-ratio:1/1;border-radius:.375rem;display:flex;font-size:.875rem;justify-content:center;padding-right:4px;position:relative;text-align:center;width:100%}.calendar-wrapper .days-grid .day.holiday{color:var(--color-holiday)}.calendar-wrapper .days-grid .day.today{border:1px solid var(--color-selected);color:var(--color-selected);font-weight:500}.calendar-wrapper .days-grid .day.selected{background-color:var(--color-selected-bg);color:var(--color-selected);font-weight:500}.calendar-wrapper .days-grid .day:not(.empty,.selected){cursor:pointer}.calendar-wrapper .days-grid .day:not(.empty,.selected):hover{background-color:var(--color-hover)}.calendar-wrapper .days-grid .day:not(.empty,.selected):active{background-color:var(--color-click)}.calendar-wrapper .days-grid .day .ad{bottom:.2rem;font-size:.475rem;font-weight:500;position:absolute;right:.2rem}.footer{align-items:center;border-top:1px solid var(--color-border);display:flex;justify-content:center;padding:.25rem}.footer .today-button{border-radius:.3rem;color:var(--color-text);cursor:pointer;font-size:.875rem;height:2rem;width:100%}.footer .today-button:hover{background-color:var(--color-hover)}.footer .today-button:active{background-color:var(--color-click)}
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Poppins:wght@300;400;500;600;700&display=swap");
+
+.nepali-calendar-popover {
+    animation: fadeIn .12s ease-out;
+    border-radius: .5rem;
+    box-shadow: 0 4px 10px 2px hsla(226, 5%, 51%, .18);
+    overflow: hidden;
+    width: max-content
+}
+
+.nepali-calendar-popover html[data-theme=dark],
+.nepali-calendar-popover[data-theme=dark],
+:root[data-theme=dark] .nepali-calendar-popover {
+    border: 1px solid hsla(0, 0%, 97%, .1);
+    box-shadow: none
+}
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+        transform: translateY(-4px)
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0)
+    }
+}
+
+.calendar-wrapper {
+    --color-background: #fff;
+    --color-text: #040609;
+    --color-text-secondary: #4a5565;
+    --color-selected: #1c46ed;
+    --color-selected-bg: rgba(28, 70, 237, .18);
+    --color-holiday: #ec0b15;
+    --color-hover: #f3f3f3;
+    --color-click: #e7e7e7;
+    --color-border: rgba(4, 6, 9, .06);
+    --status-present: #4ade80;
+    --status-absent: #f87171;
+    --status-half-day: #fbbf24;
+    --status-on-leave: #60a5fa;
+    --status-work-from-home: #34d399;
+}
+
+.calendar-wrapper html[data-theme=dark],
+.calendar-wrapper[data-theme=dark],
+:root[data-theme=dark] .calendar-wrapper {
+    --color-background: #171717;
+    --color-text: #f8f8f8;
+    --color-text-secondary: #9c9c9c;
+    --color-selected: #007be0;
+    --color-selected-bg: rgba(0, 123, 224, .18);
+    --color-holiday: #e02d2d;
+    --color-hover: hsla(0, 0%, 97%, .06);
+    --color-click: hsla(0, 0%, 97%, .2);
+    --color-border: hsla(0, 0%, 97%, .1)
+}
+
+.calendar-wrapper *,
+.calendar-wrapper :after,
+.calendar-wrapper :before {
+    border: 0 solid;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0
+}
+
+.calendar-wrapper h1,
+.calendar-wrapper h2,
+.calendar-wrapper h3,
+.calendar-wrapper h4,
+.calendar-wrapper h5,
+.calendar-wrapper h6 {
+    font-size: inherit;
+    font-weight: inherit
+}
+
+.calendar-wrapper button {
+    font-feature-settings: inherit;
+    background-color: transparent;
+    border-radius: 0;
+    color: inherit;
+    font: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    opacity: 1
+}
+
+.calendar-wrapper button,
+.calendar-wrapper input:where([type=button], [type=reset], [type=submit]) {
+    appearance: button
+}
+
+.calendar-wrapper {
+    background-color: var(--color-background);
+    color: var(--color-text);
+    font-family: 'Poppins', 'Inter', sans-serif;
+    font-optical-sizing: auto;
+    font-style: normal;
+    user-select: none;
+    width: 100% !important;
+    /* Allow it to be responsive in bshrms */
+    max-width: 24rem;
+}
+
+.calendar-wrapper .picker-action-bar {
+    border-bottom: 1px solid var(--color-border);
+    font-size: .875rem;
+    font-weight: 500;
+    padding: .25rem
+}
+
+.calendar-wrapper .picker-action-bar .back-button {
+    align-items: center;
+    border-radius: .375rem;
+    display: flex;
+    gap: .5rem;
+    padding: .375rem .5rem;
+    width: 100%
+}
+
+.calendar-wrapper .picker-action-bar .back-button:hover {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .picker-action-bar .back-button svg {
+    stroke-width: 2.5;
+    height: 1rem;
+    width: 1rem
+}
+
+.calendar-wrapper .content-scroll {
+    max-height: 16rem;
+    overflow: auto
+}
+
+.calendar-wrapper .year-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    padding: .5rem
+}
+
+.calendar-wrapper .year-grid .year {
+    cursor: pointer;
+    font-size: 1rem;
+    padding: .5rem
+}
+
+.calendar-wrapper .year-grid .year.current {
+    color: var(--color-selected)
+}
+
+.calendar-wrapper .year-grid .year:hover {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .year-grid .year:active {
+    background-color: var(--color-click)
+}
+
+.calendar-wrapper .month-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding: .5rem
+}
+
+.calendar-wrapper .month-grid .month {
+    cursor: pointer;
+    font-size: .75rem;
+    padding: .5rem
+}
+
+.calendar-wrapper .month-grid .month:hover {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .month-grid .month .np {
+    font-weight: 500
+}
+
+.calendar-wrapper .month-grid .month .ad {
+    font-size: .6875rem;
+    line-height: 1.8;
+    opacity: .8
+}
+
+.calendar-wrapper .month-grid .month.current {
+    color: var(--color-selected)
+}
+
+.calendar-wrapper .month-grid .month:active {
+    background-color: var(--color-click)
+}
+
+.calendar-wrapper .days-header .header-actions {
+    align-items: center;
+    display: flex;
+    flex-direction: row
+}
+
+.calendar-wrapper .days-header .month-button {
+    color: currentColor;
+    cursor: pointer
+}
+
+.calendar-wrapper .days-header .month-button:not(:disabled):hover>* {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .days-header .month-button:not(:disabled):active>* {
+    background-color: var(--color-click)
+}
+
+.calendar-wrapper .days-header .month-button {
+    padding: .25rem
+}
+
+.calendar-wrapper .days-header .month-button:disabled {
+    cursor: not-allowed;
+    opacity: .6
+}
+
+.calendar-wrapper .days-header .month-button .button-feedback {
+    align-items: center;
+    border-radius: .375rem;
+    display: flex;
+    font-size: 1.25rem;
+    height: 2rem;
+    justify-content: center;
+    line-height: 1.4;
+    width: 2rem
+}
+
+.calendar-wrapper .days-header .month-button .button-feedback svg {
+    stroke-width: 2.5;
+    height: .8em;
+    width: .8em
+}
+
+.calendar-wrapper .days-header .year-wrapper {
+    flex: 1
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    margin: 0 auto;
+    padding: .25rem .75rem
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button .ad {
+    font-size: .6875rem;
+    opacity: .7;
+    padding-inline: .25rem
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button:hover {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button:active {
+    background-color: var(--color-click)
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button {
+    border-radius: .375rem;
+    font-size: 1rem;
+    font-weight: 500
+}
+
+.calendar-wrapper .days-header .year-wrapper .year-button svg {
+    stroke-width: 2;
+    height: 1rem;
+    width: 1rem
+}
+
+.calendar-wrapper .days-header .selected-month {
+    align-items: center;
+    display: flex;
+    font-size: .68rem;
+    font-weight: 500;
+    justify-content: space-between;
+    padding: .25rem .5rem
+}
+
+.calendar-wrapper .week-days {
+    border-block: 1px solid var(--color-border);
+    display: grid;
+    font-size: .7rem;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    line-height: 1.4286;
+    text-align: center
+}
+
+.calendar-wrapper .week-days>:not(:last-child) {
+    border-inline-end: 1px solid var(--color-background)
+}
+
+.calendar-wrapper .week-days .day {
+    background-color: var(--color-background);
+    padding: .25rem
+}
+
+.calendar-wrapper .week-days .day.holiday {
+    color: var(--color-holiday)
+}
+
+.calendar-wrapper .days-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    padding: .25rem;
+    text-align: center
+}
+
+.calendar-wrapper .days-grid>:not(:last-child) {
+    border-bottom: 1px solid var(--color-background);
+    border-inline-end: 1px solid var(--color-background)
+}
+
+.calendar-wrapper .days-grid .day {
+    align-items: center;
+    aspect-ratio: 1/1;
+    border-radius: .375rem;
+    display: flex;
+    font-size: .875rem;
+    justify-content: center;
+    padding-right: 4px;
+    position: relative;
+    text-align: center;
+    width: 100%
+}
+
+.calendar-wrapper .days-grid .day.holiday {
+    color: var(--color-holiday)
+}
+
+.calendar-wrapper .days-grid .day.today {
+    border: 1px solid var(--color-selected);
+    color: var(--color-selected);
+    font-weight: 500
+}
+
+.calendar-wrapper .days-grid .day.selected {
+    background-color: var(--color-selected-bg);
+    color: var(--color-selected);
+    font-weight: 500
+}
+
+.calendar-wrapper .days-grid .day:not(.empty, .selected) {
+    cursor: pointer
+}
+
+.calendar-wrapper .days-grid .day:not(.empty, .selected):hover {
+    background-color: var(--color-hover)
+}
+
+.calendar-wrapper .days-grid .day[class*="status-"]:not(.empty, .selected):hover {
+    /* status tiles keep their fill; only dim slightly via filter in status rules */
+    background-color: inherit;
+}
+
+.calendar-wrapper .days-grid .day:not(.empty, .selected):active {
+    background-color: var(--color-click)
+}
+
+.calendar-wrapper .days-grid .day .ad {
+    bottom: .35rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    font-size: .55rem;
+    font-weight: 500;
+    position: absolute;
+    line-height: 1;
+    opacity: .85;
+}
+
+.footer {
+    align-items: center;
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    justify-content: center;
+    padding: .25rem
+}
+
+.footer .today-button {
+    border-radius: .3rem;
+    color: var(--color-selected);
+    background-color: var(--color-selected-bg);
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: .875rem;
+    font-weight: 500;
+    height: 2rem;
+    width: 100%;
+    transition: all 0.2s ease;
+}
+
+.footer .today-button:hover {
+    opacity: 0.85;
+}
+
+.footer .today-button:active {
+    transform: scale(0.97);
+}
+
+.footer .fiscal-button {
+    color: #059669;
+    background-color: #d1fae5;
+}
+
+.calendar-wrapper html[data-theme=dark] .footer .fiscal-button,
+.calendar-wrapper[data-theme=dark] .footer .fiscal-button,
+:root[data-theme=dark] .calendar-wrapper .footer .fiscal-button {
+    color: #34d399;
+    background-color: rgba(52, 211, 153, 0.15);
+}
+
+/* Soft rounded status tiles — inset so day cell size stays the same */
+.calendar-wrapper .days-grid .day[class*="status-"] {
+    background-color: transparent !important;
+    box-shadow: none !important;
+    position: relative;
+    z-index: 0;
+}
+
+.calendar-wrapper .days-grid .day[class*="status-"]::before {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    border-radius: 0.45rem;
+    z-index: -1;
+    pointer-events: none;
+    transition: background-color 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.calendar-wrapper .days-grid .day.status-present::before {
+    background-color: #dcfce7;
+    box-shadow: inset 0 0 0 1.5px #4ade80;
+}
+
+.calendar-wrapper .days-grid .day.status-work-from-home::before {
+    background-color: #ccfbf1;
+    box-shadow: inset 0 0 0 1.5px #2dd4bf;
+}
+
+.calendar-wrapper .days-grid .day.status-half-day::before {
+    background-color: #fef9c3;
+    box-shadow: inset 0 0 0 1.5px #facc15;
+}
+
+.calendar-wrapper .days-grid .day.status-absent::before {
+    background-color: #fee2e2;
+    box-shadow: inset 0 0 0 1.5px #f87171;
+}
+
+.calendar-wrapper .days-grid .day.status-on-leave::before {
+    background-color: #93c5fd;
+    box-shadow: inset 0 0 0 2px #2563eb;
+}
+
+.calendar-wrapper .days-grid .day.status-leave-pending::before {
+    background-color: #fff7ed;
+    box-shadow: inset 0 0 0 2px #f59e0b;
+    background-image: repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 3px,
+        rgba(245, 158, 11, 0.12) 3px,
+        rgba(245, 158, 11, 0.12) 6px
+    );
+}
+
+.calendar-wrapper .days-grid .day.status-leave-rejected::before {
+    background-color: #ffe4e6;
+    box-shadow: inset 0 0 0 1.5px #fb7185;
+}
+
+.calendar-wrapper .days-grid .day.status-holiday::before,
+.calendar-wrapper .days-grid .day.status-weekly-off::before {
+    background-color: #e9d5ff;
+    box-shadow: inset 0 0 0 1.5px #c084fc;
+}
+
+/* Hover States for status tiles */
+.calendar-wrapper .days-grid .day.status-present:hover::before,
+.calendar-wrapper .days-grid .day.status-work-from-home:hover::before,
+.calendar-wrapper .days-grid .day.status-half-day:hover::before,
+.calendar-wrapper .days-grid .day.status-absent:hover::before,
+.calendar-wrapper .days-grid .day.status-on-leave:hover::before,
+.calendar-wrapper .days-grid .day.status-leave-pending:hover::before,
+.calendar-wrapper .days-grid .day.status-leave-rejected:hover::before,
+.calendar-wrapper .days-grid .day.status-holiday:hover::before,
+.calendar-wrapper .days-grid .day.status-weekly-off:hover::before {
+    filter: brightness(0.97);
+}
+
+/* Selected or Today state inside status tiles */
+.calendar-wrapper .days-grid .day.status-present.selected,
+.calendar-wrapper .days-grid .day.status-work-from-home.selected,
+.calendar-wrapper .days-grid .day.status-half-day.selected,
+.calendar-wrapper .days-grid .day.status-absent.selected,
+.calendar-wrapper .days-grid .day.status-on-leave.selected,
+.calendar-wrapper .days-grid .day.status-leave-pending.selected,
+.calendar-wrapper .days-grid .day.status-leave-rejected.selected,
+.calendar-wrapper .days-grid .day.status-holiday.selected,
+.calendar-wrapper .days-grid .day.status-weekly-off.selected {
+    outline: 2px solid var(--color-selected) !important;
+    outline-offset: -2px;
+}
+
+.calendar-wrapper .days-grid .day.status-present.today,
+.calendar-wrapper .days-grid .day.status-work-from-home.today,
+.calendar-wrapper .days-grid .day.status-half-day.today,
+.calendar-wrapper .days-grid .day.status-absent.today,
+.calendar-wrapper .days-grid .day.status-on-leave.today,
+.calendar-wrapper .days-grid .day.status-leave-pending.today,
+.calendar-wrapper .days-grid .day.status-leave-rejected.today,
+.calendar-wrapper .days-grid .day.status-holiday.today,
+.calendar-wrapper .days-grid .day.status-weekly-off.today {
+    border: 2px solid var(--color-selected) !important;
+}
+
+/* Marker dots: leave / late / early — top-right so they don't clash with AD date */
+.calendar-wrapper .days-grid .day {
+    position: relative;
+}
+
+.calendar-wrapper .days-grid .day .day-markers {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    left: auto;
+    bottom: auto;
+    transform: none;
+    display: flex;
+    gap: 3px;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker {
+    display: block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.9);
+}
+
+/* Compact "L" badge for leave days — reads as leave, not a vague dot */
+.calendar-wrapper .days-grid .day .day-markers .marker.leave {
+    width: auto;
+    min-width: 12px;
+    height: 12px;
+    padding: 0 3px;
+    border-radius: 3px;
+    background-color: #1d4ed8;
+    color: #fff;
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 12px;
+    text-align: center;
+    font-style: normal;
+    box-shadow: none;
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.leave::before {
+    content: "L";
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.leave.pending {
+    background-color: #d97706;
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.leave.rejected {
+    background-color: #e11d48;
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.late {
+    background-color: #ea580c; /* orange — late */
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.early {
+    background-color: #7c3aed; /* purple — early exit */
+}
+
+/* Compact "O" badge — mid-day gap needs Out of Office Application */
+.calendar-wrapper .days-grid .day .day-markers .marker.ooo {
+    width: auto;
+    min-width: 12px;
+    height: 12px;
+    padding: 0 3px;
+    border-radius: 3px;
+    background-color: #0f766e; /* teal */
+    color: #fff;
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 12px;
+    text-align: center;
+    font-style: normal;
+    box-shadow: none;
+}
+
+.calendar-wrapper .days-grid .day .day-markers .marker.ooo::before {
+    content: "O";
+}
+
+.calendar-wrapper .days-grid .day.has-markers .ad {
+    bottom: 0.28rem;
+}

--- a/nepal_compliance/public/js/nepali_calendar_lib.js
+++ b/nepal_compliance/public/js/nepali_calendar_lib.js
@@ -1,15 +1,15 @@
 (function (global, factory) {
   typeof exports === "object" && typeof module !== "undefined"
     ? factory(
-        exports,
-        require("react"),
-        require("nepali-date"),
-        require("react-dom/client"),
-      )
+      exports,
+      require("react"),
+      require("nepali-date"),
+      require("react-dom/client"),
+    )
     : typeof define === "function" && define.amd
       ? define(["exports", "react", "nepali-date", "react-dom/client"], factory)
       : ((global =
-          typeof globalThis !== "undefined" ? globalThis : global || self),
+        typeof globalThis !== "undefined" ? globalThis : global || self),
         factory(
           (global.NepaliCalendarLib = {}),
           global.React,
@@ -40,7 +40,7 @@
 
   const MONTH_START_INDEX = 0;
   const MONTH_END_INDEX = 11;
-  function NepaliCalendarView({ selectedDateAD, selectedDateBS, onSelect }) {
+  function NepaliCalendarView({ selectedDateAD, selectedDateBS, onSelect, onMonthChange, events, minBsYear, minBsMonthIndex }) {
     const today = React.useMemo(() => new nepaliDate.NepaliDate(), []);
     const selectedNepaliDate = React.useMemo(() => {
       if (selectedDateBS) return nepaliDate.NepaliDate.fromBS(selectedDateBS);
@@ -71,9 +71,18 @@
       () => calendar.getMonth(currentMonthIndex),
       [calendar, currentMonthIndex],
     );
+    const isBeforeMin = (year, monthIndex) =>
+      minBsYear != null &&
+      (year < minBsYear ||
+        (year === minBsYear && monthIndex < (minBsMonthIndex || 0)));
     const canGoPrev =
-      currentYear > nepaliDate.NepaliCalendar.minYear ||
-      currentMonthIndex > MONTH_START_INDEX;
+      (currentYear > nepaliDate.NepaliCalendar.minYear ||
+        currentMonthIndex > MONTH_START_INDEX) &&
+      !(
+        minBsYear != null &&
+        (currentYear < minBsYear ||
+          (currentYear === minBsYear && currentMonthIndex <= (minBsMonthIndex || 0)))
+      );
     const canGoNext =
       currentYear < nepaliDate.NepaliCalendar.maxYear ||
       currentMonthIndex < MONTH_END_INDEX;
@@ -99,14 +108,22 @@
       setCurrentYear(y);
       setCurrentMonthIndex(m);
     }, [currentYear, currentMonthIndex, canGoNext]);
-    const handleYearSelect = React.useCallback((year) => {
-      setCurrentYear(year);
-      setMode("month");
-    }, []);
-    const handleMonthSelect = React.useCallback((month) => {
-      setCurrentMonthIndex(month);
-      setMode("day");
-    }, []);
+    const handleYearSelect = React.useCallback(
+      (year) => {
+        if (minBsYear != null && year < minBsYear) year = minBsYear;
+        setCurrentYear(year);
+        setMode("month");
+      },
+      [minBsYear],
+    );
+    const handleMonthSelect = React.useCallback(
+      (month) => {
+        if (isBeforeMin(currentYear, month)) month = minBsMonthIndex || 0;
+        setCurrentMonthIndex(month);
+        setMode("day");
+      },
+      [currentYear, minBsYear, minBsMonthIndex],
+    );
     const handleDateSelect = React.useCallback(
       (date) =>
         onSelect === null || onSelect === void 0 ? void 0 : onSelect(date),
@@ -119,10 +136,51 @@
       setCurrentMonthIndex(today.monthIndex);
       setMode("day");
     }, [today, onSelect]);
+    const handleFiscalYearStartClick = React.useCallback(() => {
+      const today = new nepaliDate.NepaliDate();
+      const isBeforeShrawan = today.monthIndex < 3;
+      let fiscalYear = isBeforeShrawan ? today.year - 1 : today.year;
+      // Respect past-month navigation restriction
+      if (
+        minBsYear != null &&
+        (fiscalYear < minBsYear ||
+          (fiscalYear === minBsYear && 3 < (minBsMonthIndex || 0)))
+      ) {
+        fiscalYear = minBsYear;
+        setCurrentYear(minBsYear);
+        setCurrentMonthIndex(minBsMonthIndex || 0);
+        setMode("day");
+        return;
+      }
+      const shrawanFirst = new nepaliDate.NepaliDate(fiscalYear, 3, 1);
+      onSelect === null || onSelect === void 0 ? void 0 : onSelect(shrawanFirst);
+      setCurrentYear(fiscalYear);
+      setCurrentMonthIndex(3);
+      setMode("day");
+    }, [onSelect, minBsYear, minBsMonthIndex]);
     const currentMonthStartADYear = React.useMemo(
       () => calendar.getMonthAdYear(currentMonthIndex),
       [calendar, currentMonthIndex],
     );
+    React.useEffect(() => {
+      if (!onMonthChange || !monthData || !monthData.days) return;
+      const days = monthData.days.filter((d) => d && d.date);
+      if (!days.length) return;
+      const from_date = days[0].date.format({
+        format: "YYYY-MM-DD",
+        calendar: "AD",
+      });
+      const to_date = days[days.length - 1].date.format({
+        format: "YYYY-MM-DD",
+        calendar: "AD",
+      });
+      onMonthChange({
+        from_date,
+        to_date,
+        year: currentYear,
+        monthIndex: currentMonthIndex,
+      });
+    }, [monthData, currentYear, currentMonthIndex, onMonthChange]);
     return /*#__PURE__*/ React.createElement(
       "div",
       {
@@ -132,41 +190,43 @@
       },
       mode === "year" &&
         /*#__PURE__*/ React.createElement(CalendarYears, {
-          currentYear: currentYear,
-          onSelect: handleYearSelect,
-          onBack: () => setMode("day"),
-        }),
+        currentYear: currentYear,
+        onSelect: handleYearSelect,
+        onBack: () => setMode("day"),
+      }),
       mode === "month" &&
         /*#__PURE__*/ React.createElement(CalendarMonths, {
-          currentMonth: currentMonthIndex,
-          currentYear: currentYear,
-          onSelect: handleMonthSelect,
-          onBack: () => setMode("year"),
-        }),
+        currentMonth: currentMonthIndex,
+        currentYear: currentYear,
+        onSelect: handleMonthSelect,
+        onBack: () => setMode("year"),
+      }),
       mode === "day" &&
         /*#__PURE__*/ React.createElement(CalendarDays, {
-          selectedADString:
-            selectedNepaliDate === null || selectedNepaliDate === void 0
-              ? void 0
-              : selectedNepaliDate.format({
-                  format: "YYYY-MM-DD",
-                  calendar: "AD",
-                }),
-          weeks: chunkWeeks(monthData.days),
-          today: today,
-          monthAd: monthData.month.ad,
-          monthNp: monthData.month.np,
-          yearNp: nepaliDate.formatNumber(currentYear, "ne"),
-          yearEn: currentYear,
-          yearAd: currentMonthStartADYear,
-          onClickPrev: handlePrevMonth,
-          onClickNext: handleNextMonth,
-          onClickYear: () => setMode("year"),
-          onClickToday: handleTodayClick,
-          onSelectDate: handleDateSelect,
-          nextDisabled: !canGoNext,
-          prevDisabled: !canGoPrev,
-        }),
+        selectedADString:
+          selectedNepaliDate === null || selectedNepaliDate === void 0
+            ? void 0
+            : selectedNepaliDate.format({
+              format: "YYYY-MM-DD",
+              calendar: "AD",
+            }),
+        weeks: chunkWeeks(monthData.days),
+        today: today,
+        monthAd: monthData.month.ad,
+        monthNp: monthData.month.np,
+        yearNp: nepaliDate.formatNumber(currentYear, "ne"),
+        yearEn: currentYear,
+        yearAd: currentMonthStartADYear,
+        onClickPrev: handlePrevMonth,
+        onClickNext: handleNextMonth,
+        onClickYear: () => setMode("year"),
+        onClickToday: handleTodayClick,
+        onClickFiscalYearFirstMonth: handleFiscalYearStartClick,
+        onSelectDate: handleDateSelect,
+        nextDisabled: !canGoNext,
+        prevDisabled: !canGoPrev,
+        events: events,
+      }),
     );
   }
   function chunkWeeks(days) {
@@ -281,6 +341,8 @@
     today,
     selectedADString,
     onClickToday,
+    onClickFiscalYearFirstMonth,
+    events,
   }) {
     return /*#__PURE__*/ React.createElement(
       "div",
@@ -425,14 +487,14 @@
         },
         nepaliDate.WEEKDAY_SHORT_NE.map((day, index) =>
           /*#__PURE__*/ React.createElement(
-            "span",
-            {
-              key: day,
-              className: clsx("day", index === 6 && "holiday"),
-              "aria-label": day,
-            },
-            day,
-          ),
+          "span",
+          {
+            key: day,
+            className: clsx("day", index === 6 && "holiday"),
+            "aria-label": day,
+          },
+          day,
+        ),
         ),
       ),
       /*#__PURE__*/ React.createElement(
@@ -443,74 +505,184 @@
         },
         weeks.map((week, weekIndex) =>
           /*#__PURE__*/ React.createElement(
-            React.Fragment,
-            {
-              key: `week-${weekIndex}`,
-            },
-            week.map((day, dayIndex) => {
-              if (!day) {
-                return /*#__PURE__*/ React.createElement("div", {
-                  key: `day-${weekIndex}-${dayIndex}`,
-                  className: "day empty",
-                  role: "gridcell",
-                });
+          React.Fragment,
+          {
+            key: `week-${weekIndex}`,
+          },
+          week.map((day, dayIndex) => {
+            if (!day) {
+              return /*#__PURE__*/ React.createElement("div", {
+                key: `day-${weekIndex}-${dayIndex}`,
+                className: "day empty",
+                role: "gridcell",
+              });
+            }
+            const isToday =
+              day.date.year === today.year &&
+              day.date.monthIndex === today.monthIndex &&
+              day.date.day === today.day;
+            const isSelected =
+              selectedADString ===
+              day.date.format({
+                format: "YYYY-MM-DD",
+                calendar: "AD",
+              });
+            const adDate = day.date.toAD();
+            const adKey = [
+              adDate.getUTCFullYear(),
+              String(adDate.getUTCMonth() + 1).padStart(2, "0"),
+              String(adDate.getUTCDate()).padStart(2, "0"),
+            ].join("-");
+            const rawEvent = events && (events[adKey] || events[day.date.format({
+              format: "YYYY-MM-DD",
+              calendar: "AD",
+            })]);
+            let eventStatus = null;
+            const markers = { leave: false, late: false, early: false, ooo: false, leaveKind: "" };
+            if (typeof rawEvent === "string") {
+              eventStatus = rawEvent;
+              if (
+                rawEvent === "On Leave" ||
+                rawEvent === "Leave Pending" ||
+                rawEvent === "Leave Rejected"
+              ) {
+                markers.leave = true;
+                markers.leaveKind =
+                  rawEvent === "Leave Pending"
+                    ? "pending"
+                    : rawEvent === "Leave Rejected"
+                      ? "rejected"
+                      : "";
               }
-              const isToday =
-                day.date.year === today.year &&
-                day.date.monthIndex === today.monthIndex &&
-                day.date.day === today.day;
-              const isSelected =
-                selectedADString ===
-                day.date.format({
+            } else if (rawEvent && typeof rawEvent === "object") {
+              eventStatus = rawEvent.status || null;
+              const appStatus = rawEvent.leave_app_status || null;
+              const isRejectedOnly =
+                appStatus === "Rejected" || eventStatus === "Leave Rejected";
+              markers.leave =
+                !!rawEvent.leave ||
+                eventStatus === "On Leave" ||
+                eventStatus === "Leave Pending" ||
+                eventStatus === "Leave Rejected" ||
+                (appStatus === "Pending" || appStatus === "Approved");
+              // Rejected leave on a Present/Absent day must not keep the "L" badge
+              if (
+                isRejectedOnly &&
+                eventStatus &&
+                eventStatus !== "Leave Rejected"
+              ) {
+                markers.leave = false;
+              }
+              if (appStatus === "Pending" || eventStatus === "Leave Pending") {
+                markers.leaveKind = "pending";
+              } else if (appStatus === "Rejected" || eventStatus === "Leave Rejected") {
+                markers.leaveKind = "rejected";
+              } else if (markers.leave) {
+                markers.leaveKind = "";
+              }
+              markers.late = !!rawEvent.late;
+              markers.early = !!rawEvent.early;
+              markers.ooo = !!rawEvent.ooo_required;
+            }
+            // Weekly Off uses holiday-like styling
+            if (eventStatus === "Weekly Off") {
+              eventStatus = "Weekly Off";
+            }
+            const statusClass = eventStatus
+              ? `status-${String(eventStatus).toLowerCase().replace(/ /g, "-")}`
+              : "";
+            const hasMarkers = markers.leave || markers.late || markers.early || markers.ooo;
+            // Colored rectangle is CSS ::before on status-* (inset); no inline fill
+
+            return /*#__PURE__*/ React.createElement(
+              "button",
+              {
+                key: `day-${weekIndex}-${dayIndex}`,
+                type: "button",
+                onClick: () =>
+                  onSelectDate === null || onSelectDate === void 0
+                    ? void 0
+                    : onSelectDate(day.date),
+                className: clsx(
+                  "day",
+                  (dayIndex + 1) % 7 === 0 && "holiday",
+                  isToday && "today",
+                  isSelected && "selected",
+                  statusClass,
+                  hasMarkers && "has-markers",
+                ),
+                "data-ad": adKey,
+                "data-status": eventStatus || "",
+                role: "gridcell",
+                "aria-label": `Nepali date ${day.date.format({
                   format: "YYYY-MM-DD",
-                  calendar: "AD",
-                });
-              return /*#__PURE__*/ React.createElement(
-                "button",
+                  calendar: "BS",
+                })}${eventStatus ? `, ${eventStatus}` : ""}`,
+                "aria-current": isToday ? "date" : undefined,
+                "aria-selected": isSelected,
+              },
+              isToday &&
+                /*#__PURE__*/ React.createElement("span", {
+                  className: "today-indicator",
+                  "aria-hidden": "true",
+                }),
+              day.np,
+              /*#__PURE__*/ React.createElement(
+                "span",
                 {
-                  key: `day-${weekIndex}-${dayIndex}`,
-                  type: "button",
-                  onClick: () =>
-                    onSelectDate === null || onSelectDate === void 0
-                      ? void 0
-                      : onSelectDate(day.date),
-                  className: clsx(
-                    "day",
-                    (dayIndex + 1) % 7 === 0 && "holiday",
-                    isToday && "today",
-                    isSelected && "selected",
-                  ),
-                  role: "gridcell",
-                  "aria-label": `Nepali date ${day.date.format({
-                    format: "YYYY-MM-DD",
-                    calendar: "BS",
-                  })}`,
-                  "aria-current": isToday ? "date" : undefined,
-                  "aria-selected": isSelected,
+                  className: "ad",
+                  "aria-hidden": "true",
                 },
-                isToday &&
-                  /*#__PURE__*/ React.createElement("span", {
-                    className: "today-indicator",
-                    "aria-hidden": "true",
-                  }),
-                day.np,
+                day.ad,
+              ),
+              hasMarkers &&
                 /*#__PURE__*/ React.createElement(
                   "span",
                   {
-                    className: "ad",
+                    className: "day-markers",
                     "aria-hidden": "true",
                   },
-                  day.ad,
+                  markers.leave &&
+                    /*#__PURE__*/ React.createElement("i", {
+                      className: clsx(
+                        "marker",
+                        "leave",
+                        markers.leaveKind === "pending" && "pending",
+                        markers.leaveKind === "rejected" && "rejected",
+                      ),
+                      title:
+                        markers.leaveKind === "pending"
+                          ? "Leave pending"
+                          : markers.leaveKind === "rejected"
+                            ? "Leave rejected"
+                            : "Leave",
+                    }),
+                  markers.late &&
+                    /*#__PURE__*/ React.createElement("i", {
+                      className: "marker late",
+                      title: "Late",
+                    }),
+                  markers.early &&
+                    /*#__PURE__*/ React.createElement("i", {
+                      className: "marker early",
+                      title: "Early exit",
+                    }),
+                  markers.ooo &&
+                    /*#__PURE__*/ React.createElement("i", {
+                      className: "marker ooo",
+                      title: "Out of office form required",
+                    }),
                 ),
-              );
-            }),
-          ),
+            );
+          }),
+        ),
         ),
       ),
       /*#__PURE__*/ React.createElement(
         "div",
         {
           className: "footer",
+          style: { display: "flex", gap: "8px", justifyContent: "center" }
         },
         /*#__PURE__*/ React.createElement(
           "button",
@@ -521,6 +693,16 @@
             "aria-label": "Go to today's date",
           },
           /*#__PURE__*/ React.createElement("span", null, "\u0906\u091C"),
+        ),
+        /*#__PURE__*/ React.createElement(
+          "button",
+          {
+            onClick: onClickFiscalYearFirstMonth,
+            type: "button",
+            className: "today-button fiscal-button",
+            "aria-label": "Go to current fiscal year first month",
+          },
+          /*#__PURE__*/ React.createElement("span", null, "\u091A\u093E\u0932\u0941 \u0906.\u0935."),
         ),
       ),
     );
@@ -568,9 +750,9 @@
     }
     root.render(
       /*#__PURE__*/ React.createElement(
-        NepaliCalendarView,
-        Object.assign({}, props),
-      ),
+      NepaliCalendarView,
+      Object.assign({}, props),
+    ),
     );
   }
 


### PR DESCRIPTION
Updates the shared Nepali calendar datepicker widget (`nepali_calendar_lib.js` + `nepali_calendar.css`).

### What's new

- **Current Fiscal Year button** — one click jumps the datepicker to 1 Shrawan of the current Nepali fiscal year (clamped to the available calendar range), next to the existing "Today" button.
- **Month / year quick select** — jump directly to any BS month/year instead of paging through months.
- **Day markers support** — days can render status markers (colored dots) from a caller-supplied map; inert on its own, used by the upcoming attendance calendar (separate PR).
- Min-year clamping and assorted widget styling for the above.

### Notes for reviewers

- Both assets are already registered in `hooks.py` (`app_include_css` / `app_include_js`) — no wiring changes.
- Size is over the 300-line soft threshold, but this is one atomic widget update; the two files are byte-identical to what is currently running in production.

### Testing

- [x] `node --check` passes (plain `React.createElement`, no JSX build step required)
- [x] These exact file versions are live in production on the hotfix branch — datepicker rendering, fiscal-year jump, and month/year select verified in daily use
- [ ] Maintainer: hard-refresh desk and open any Nepali date field → confirm FY button jumps to 1 Shrawan of the current BS fiscal year
