### PR TITLE
Add permission checks to privileged whitelisted endpoints

### DIFF
--- a/nepal_compliance/cbms_api.py
+++ b/nepal_compliance/cbms_api.py
@@ -310,6 +310,9 @@ def post_sales_invoice_status(doc_name: Any, method: Optional[str] = None) -> di
 
 @frappe.whitelist()
 def sync_failed_cbms_invoices():
+    if not frappe.has_permission("CBMS Settings", "write"):
+        frappe.throw(_("You are not permitted to sync CBMS invoices."), frappe.PermissionError)
+
     failed_invoices = frappe.get_all(
         "Sales Invoice",
         filters={"docstatus": 1, "cbms_status": ["!=", "Success"]},

--- a/nepal_compliance/custom_code/leave_allocation/monthly_leave_bs.py
+++ b/nepal_compliance/custom_code/leave_allocation/monthly_leave_bs.py
@@ -107,6 +107,9 @@ def get_bs_eligible_leave_types():
 @frappe.whitelist()
 def allocate_monthly_leave_bs(bs_year: int, bs_month: int, leave_types: Optional[Union[str, List[str]]] = None, force: bool = False, silent: bool = False) -> dict:
 
+    if not frappe.has_permission("Leave Allocation", "write"):
+        frappe.throw(_("You are not permitted to allocate leave."), frappe.PermissionError)
+
     if isinstance(leave_types, str):
         import json
         leave_types = json.loads(leave_types)

--- a/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
+++ b/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
@@ -128,7 +128,7 @@ class TestMonthlyLeaveBS(unittest.TestCase):
             has_permission=has_permission,
             PermissionError=DummyPermissionError,
             throw=throw,
-            utils=SimpleNamespace(cint=lambda x: int(x)),
+            utils=SimpleNamespace(cint=int),
         )
         with patch(
             "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.frappe",

--- a/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
+++ b/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
@@ -109,6 +109,28 @@ class TestMonthlyLeaveBS(unittest.TestCase):
             result = allocate_monthly_leave_bs(2080, 2, leave_types=None, force=True, silent=True)
             self.assertEqual(result["status"], "skipped")
 
+    def test_denies_allocation_without_permission(self):
+        """Should refuse to allocate when the user lacks Leave Allocation write access."""
+
+        class DummyPermissionError(Exception):
+            pass
+
+        def throw(msg="", exc=Exception, **kwargs):
+            raise exc(msg)
+
+        frappe_ns = SimpleNamespace(
+            has_permission=lambda doctype, perm: False,
+            PermissionError=DummyPermissionError,
+            throw=throw,
+            utils=SimpleNamespace(cint=lambda x: int(x)),
+        )
+        with patch(
+            "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.frappe",
+            frappe_ns,
+        ):
+            with self.assertRaises(DummyPermissionError):
+                allocate_monthly_leave_bs(2080, 2, ["Casual Leave"], force=True, silent=True)
+
     def test_handles_exceptions_and_returns_error(self):
         """Should catch exceptions and return error without raising."""
         def raise_exception(*args, **kwargs):

--- a/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
+++ b/nepal_compliance/custom_code/leave_allocation/test_monthly_leave_bs.py
@@ -118,8 +118,14 @@ class TestMonthlyLeaveBS(unittest.TestCase):
         def throw(msg="", exc=Exception, **kwargs):
             raise exc(msg)
 
+        permission_calls = []
+
+        def has_permission(doctype, perm):
+            permission_calls.append((doctype, perm))
+            return False
+
         frappe_ns = SimpleNamespace(
-            has_permission=lambda doctype, perm: False,
+            has_permission=has_permission,
             PermissionError=DummyPermissionError,
             throw=throw,
             utils=SimpleNamespace(cint=lambda x: int(x)),
@@ -130,6 +136,8 @@ class TestMonthlyLeaveBS(unittest.TestCase):
         ):
             with self.assertRaises(DummyPermissionError):
                 allocate_monthly_leave_bs(2080, 2, ["Casual Leave"], force=True, silent=True)
+
+        self.assertEqual(permission_calls, [("Leave Allocation", "write")])
 
     def test_handles_exceptions_and_returns_error(self):
         """Should catch exceptions and return error without raising."""

--- a/nepal_compliance/setup/install.py
+++ b/nepal_compliance/setup/install.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 @frappe.whitelist()
 def generate_test_masters(docname: Optional[str] = None) -> bool:
+    if not frappe.has_permission("IRD Certification", "write"):
+        frappe.throw(_("You are not permitted to generate test data."), frappe.PermissionError)
+
     if not docname:
         frappe.throw(_("Missing IRD Certification document name."))
     settings = frappe.get_doc("IRD Certification", docname)
@@ -112,6 +115,9 @@ def generate_test_masters(docname: Optional[str] = None) -> bool:
 
 @frappe.whitelist()
 def generate_test_transactions(docname: Optional[str] = None) -> bool:
+    if not frappe.has_permission("IRD Certification", "write"):
+        frappe.throw(_("You are not permitted to generate test data."), frappe.PermissionError)
+
     if not docname:
         frappe.throw(_("Missing IRD Certification document name."))
     try:
@@ -239,6 +245,9 @@ def generate_test_transactions(docname: Optional[str] = None) -> bool:
 
 @frappe.whitelist()
 def check_test_data_status(docname: Optional[str] = None) -> dict[str, bool]:
+    if not frappe.has_permission("IRD Certification", "read"):
+        frappe.throw(_("You are not permitted to view test data status."), frappe.PermissionError)
+
     if not docname:
         frappe.throw(_("Missing IRD Certification document name."))
     

--- a/nepal_compliance/setup/uninstall.py
+++ b/nepal_compliance/setup/uninstall.py
@@ -4,6 +4,9 @@ from typing import Optional
 
 @frappe.whitelist()
 def clear_test_data(docname: Optional[str] = None) -> bool:
+    if not frappe.has_permission("IRD Certification", "write"):
+        frappe.throw(_("You are not permitted to clear test data."), frappe.PermissionError)
+
     if not docname:
         frappe.throw(_("Missing IRD Certification document name."))
 


### PR DESCRIPTION
Fixes #304

### Problem

Several endpoints marked with `@frappe.whitelist` perform privileged work but never check the caller's permissions. `@frappe.whitelist` only blocks Guest access, so any signed in user, down to a plain Employee, can call them directly, even though the buttons that trigger them sit on System Manager or Accounts Manager forms.

### Fix

Add a `frappe.has_permission` check to each endpoint, matching the doctype whose form the action belongs to. This follows the pattern already used by `get_bs_eligible_leave_types`.

| Endpoint | Check |
| --- | --- |
| `sync_failed_cbms_invoices` | write on CBMS Settings |
| `allocate_monthly_leave_bs` | write on Leave Allocation |
| `generate_test_masters` | write on IRD Certification |
| `generate_test_transactions` | write on IRD Certification |
| `clear_test_data` | write on IRD Certification |
| `check_test_data_status` | read on IRD Certification |

The scheduler calls `allocate_monthly_leave_bs` as Administrator, which keeps full permission, so the daily job is unaffected. `frappe.PermissionError` is used so a denied call returns a proper 403.

### Tests

Added a test that `allocate_monthly_leave_bs` refuses to run without the Leave Allocation permission. The existing leave allocation tests still pass.
