### PR TITLE
Queue the loaded Sales Invoice document for CBMS, not its name

### DIFF
--- a/nepal_compliance/cbms_api.py
+++ b/nepal_compliance/cbms_api.py
@@ -270,11 +270,11 @@ def post_sales_invoice_or_return_to_cbms(doc_name: Any, method: Optional[str] = 
             return config
         
         enqueue(
-            method=cbms_integration.send_to_cbms,  
+            method=cbms_integration.send_to_cbms,
             queue="short",
             timeout=60,
             is_async=True,
-            doc=doc_name 
+            doc=doc,
         )
         frappe.msgprint(_("Invoice/Return has been queued for sending to CBMS."))
         return {"message": _("Request processed successfully"), "status": "queued"}

--- a/nepal_compliance/test/test_cbms_api.py
+++ b/nepal_compliance/test/test_cbms_api.py
@@ -155,6 +155,26 @@ class TestCBMSWhitelist(unittest.TestCase):
         mock_enqueue.assert_called_once()
         self.assertEqual(result["status"], "queued")
 
+    @patch("nepal_compliance.cbms_api.enqueue")
+    @patch("nepal_compliance.cbms_api.frappe.get_doc")
+    def test_post_sales_invoice_enqueues_loaded_document(self, mock_get_doc, mock_enqueue):
+        # send_to_cbms works on the Sales Invoice document itself, so the queued
+        # job must receive the loaded document rather than the raw name. Passing
+        # the name string makes send_to_cbms fail on a string and its own error
+        # handler fail again, so the invoice is filed nowhere.
+        test_doc = MagicMock()
+        mock_get_doc.return_value = test_doc
+
+        with patch.object(
+            CBMSIntegration,
+            "is_cbms_configured",
+            return_value={"status": "configured"},
+        ):
+            post_sales_invoice_or_return_to_cbms("INV-001")
+
+        mock_enqueue.assert_called_once()
+        self.assertIs(mock_enqueue.call_args.kwargs["doc"], test_doc)
+
     @patch("nepal_compliance.cbms_api.frappe.db.exists")
     def test_post_sales_invoice_status_not_found(self, mock_exists):
 


### PR DESCRIPTION
Fixes #306

### Problem

`post_sales_invoice_or_return_to_cbms` loads the Sales Invoice into `doc` but then queues `send_to_cbms` with the raw `doc_name` instead of `doc`. On the whitelisted path `doc_name` is the invoice name, so `send_to_cbms` receives a string and fails on the first attribute access (`self.doc.is_return`). Its `except` block then calls `doc.reload()` on the same string and fails again, so the job dies without writing `cbms_status` or `cbms_response`. The invoice is filed nowhere, is left with no failure state, and is skipped by the retry sweep because it is never marked failed.

### Fix

Queue the loaded document, matching how `sync_failed_cbms_invoices` already calls `send_to_cbms`.

### Tests

Added a test that the queued job receives the loaded document rather than the name. The existing CBMS tests still pass.
