### PR TITLE
Guard evaluate_tax_formula against expensive expressions

### DIFF
--- a/nepal_compliance/test/test_utils.py
+++ b/nepal_compliance/test/test_utils.py
@@ -1,0 +1,30 @@
+import unittest
+
+from nepal_compliance.utils import evaluate_tax_formula
+
+
+class TestEvaluateTaxFormula(unittest.TestCase):
+    def test_valid_formula_is_evaluated(self):
+        self.assertEqual(evaluate_tax_formula("taxable_salary * 0.1", 1000), 100.0)
+
+    def test_rejects_power_operator(self):
+        # 9**9**9 would hang the worker if it reached safe_eval.
+        with self.assertRaises(Exception):
+            evaluate_tax_formula("9**9**9", 1000)
+
+    def test_rejects_list_allocation(self):
+        # [0]*999999999 would exhaust memory if it reached safe_eval.
+        with self.assertRaises(Exception):
+            evaluate_tax_formula("[0]*999999999", 1000)
+
+    def test_rejects_overly_long_formula(self):
+        with self.assertRaises(Exception):
+            evaluate_tax_formula("1+" * 400, 1000)
+
+    def test_rejects_empty_formula(self):
+        with self.assertRaises(Exception):
+            evaluate_tax_formula("   ", 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -1,9 +1,20 @@
+import re
+
 import frappe
 from frappe import _
 from frappe.utils import flt
 from frappe.utils.safe_exec import safe_eval
 from frappe.model.naming import make_autoname
 from typing import Union
+
+# A tax formula is arithmetic over taxable_salary, so it only needs digits, the
+# usual operators, comparisons, parentheses, commas and the names used in the
+# evaluation context. Anything else is rejected. safe_eval already blocks code
+# execution, but it does not stop an expression from hanging or exhausting
+# memory, so the length limit, the character allow list and the check on the
+# power operator keep inputs like 9**9**9 or [0]*10**9 out.
+MAX_TAX_FORMULA_LENGTH = 500
+ALLOWED_TAX_FORMULA = re.compile(r"^[A-Za-z0-9_.,+\-*/()<>=!%\s]+$")
 
 def prevent_invoice_deletion(doc, method):
     if (doc.docstatus == 1):
@@ -39,6 +50,15 @@ def custom_autoname(doc, method):
 
 @frappe.whitelist()
 def evaluate_tax_formula(formula: str, taxable_salary: Union[str, float]) -> float:
+    if not isinstance(formula, str) or not formula.strip():
+        frappe.throw(_("Tax formula is missing."))
+
+    if len(formula) > MAX_TAX_FORMULA_LENGTH:
+        frappe.throw(_("Tax formula is too long. Keep it under {0} characters.").format(MAX_TAX_FORMULA_LENGTH))
+
+    if "**" in formula or not ALLOWED_TAX_FORMULA.match(formula):
+        frappe.throw(_("Tax formula contains characters or operators that are not allowed."))
+
     try:
         taxable_salary = flt(taxable_salary)
         context = {


### PR DESCRIPTION
Fixes #308

### Problem

`evaluate_tax_formula` passes a caller supplied formula to `safe_eval`. `safe_eval` blocks code execution, so this is not remote code execution, but it does not stop an expression from hanging or exhausting memory. The endpoint is whitelisted, so any signed in user can send `9**9**9` or `[0]*999999999` and tie up a worker. The evaluation is synchronous, so a handful of calls can exhaust the worker pool.

### Fix

A tax formula is arithmetic over `taxable_salary`, so the input is now bounded: a length limit, a character allow list (digits, the usual operators, comparisons, parentheses, commas and names), and a check that rejects the power operator. Valid formulas are unaffected.

### Tests

Added tests for a valid formula and for the rejected cases (power operator, list allocation, over length, empty).
