### PR TITLE
feat(vat): add VAT template helpers and purchase invoice attachment check

### DIFF
--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -1,7 +1,7 @@
 import json
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import flt, get_link_to_form
 from frappe.utils.safe_exec import safe_eval
 from frappe.model.naming import make_autoname
 from typing import Union
@@ -235,3 +235,270 @@ def tax_row_amount(tax):
         if tax.tax_amount_after_discount_amount is not None
         else tax.tax_amount
     )
+
+VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
+
+def get_configured_vat_accounts():
+    settings = frappe.get_cached_doc("Nepal Compliance Settings")
+    accounts = {}
+    for row in settings.get("vat_accounts") or []:
+        if row.company:
+            accounts[row.company] = {
+                "sales": row.sales_vat_account,
+                "purchase": row.purchase_vat_account,
+            }
+    return accounts
+
+VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
+
+def get_or_create_vat_exempt_template(company, vat_account):
+    existing = frappe.get_all(
+        "Item Tax Template",
+        filters={"company": company, "title": VAT_EXEMPT_TEMPLATE_TITLE},
+        pluck="name",
+    )
+    if existing:
+        template = frappe.get_doc("Item Tax Template", existing[0])
+        if (
+            len(template.taxes) != 1
+            or template.taxes[0].tax_type != vat_account
+            or flt(template.taxes[0].tax_rate) != 0
+        ):
+            template.taxes = [{"tax_type": vat_account, "tax_rate": 0}]
+            template.save(ignore_permissions=True)
+        return template.name
+
+    template = frappe.get_doc({
+        "doctype": "Item Tax Template",
+        "title": VAT_EXEMPT_TEMPLATE_TITLE,
+        "company": company,
+        "taxes": [{"tax_type": vat_account, "tax_rate": 0}],
+    }).insert(ignore_permissions=True)
+    return template.name
+
+def apply_vat_exemption_for_nontaxable_items(doc, method):
+    flagged = [item for item in doc.get("items") or [] if item.get("is_nontaxable_item")]
+    if not flagged:
+        return
+
+    side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+    vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+    if not vat_account:
+        frappe.msgprint(
+            _("Some items are marked as non-taxable, but no {0} VAT account is configured for company {1}. VAT will still be charged on them. Please set the account under {2}.").format(
+                _("Sales") if side == "sales" else _("Purchase"),
+                frappe.bold(doc.company),
+                get_link_to_form("Nepal Compliance Settings", "Nepal Compliance Settings", _("Nepal Compliance Settings > IRD VAT Accounts")),
+            ),
+            indicator="orange",
+            alert=True,
+        )
+        return
+
+    if not any(tax.account_head == vat_account for tax in doc.get("taxes") or []):
+        return
+
+    template_name = get_or_create_vat_exempt_template(doc.company, vat_account)
+    for item in flagged:
+        item.item_tax_template = template_name
+        item.item_tax_rate = json.dumps({vat_account: 0})
+
+@frappe.whitelist()
+def is_purchase_invoice_attachment_required() -> int:
+    settings = frappe.get_cached_doc("Nepal Compliance Settings")
+    return int(bool(settings.get("require_purchase_invoice_attachment")))
+
+def require_purchase_invoice_attachment(doc, method):
+    if doc.doctype != "Purchase Invoice":
+        return
+
+    settings = frappe.get_cached_doc("Nepal Compliance Settings")
+    if not settings.get("require_purchase_invoice_attachment"):
+        return
+
+    if not doc.get("attach_purchase_invoice"):
+        frappe.throw(_("<b>Attach Purchase Invoice</b> is mandatory before submitting a Purchase Invoice. Please attach the supplier's invoice document."))
+
+def validate_duplicate_bill_no(doc, method):
+    if doc.doctype != "Purchase Invoice":
+        return
+
+    settings = frappe.get_cached_doc("Nepal Compliance Settings")
+    if not settings.get("enable_duplicate_bill_no_check"):
+        return
+
+    if not doc.bill_no or not doc.supplier:
+        return
+
+    normalized_bill_no = str(doc.bill_no).strip().lstrip("0") or "0"
+
+    fiscal_year = None
+    if doc.posting_date:
+        fiscal_year = frappe.db.get_value(
+            "Fiscal Year",
+            {
+                "year_start_date": ["<=", doc.posting_date],
+                "year_end_date": [">=", doc.posting_date]
+            },
+            ["name", "year_start_date", "year_end_date"],
+            as_dict=True
+        )
+    if not fiscal_year:
+        return
+
+    invoices = frappe.get_all(
+        "Purchase Invoice",
+        filters={
+            "supplier": doc.supplier,
+            "docstatus": ["<", 2],
+            "name": ["!=", doc.name],
+            "posting_date": ["between", [fiscal_year.year_start_date, fiscal_year.year_end_date]]
+        },
+        fields=["name", "bill_no"]
+    )
+
+    for inv in invoices:
+        existing_bill = (str(inv.bill_no or "").strip().lstrip("0") or "0")
+        if existing_bill.lower() == normalized_bill_no.lower():
+            supplier_name = frappe.db.get_value("Supplier", doc.supplier, "supplier_name") or doc.supplier
+            invoice_link = get_link_to_form("Purchase Invoice", inv.name)
+            frappe.msgprint(
+                _("<b>Duplicate Bill No Detected.</b><br><br>Supplier: {0}<br>Bill No: {1}<br>Fiscal Year: {2}<br><br>Existing Invoice: {3}<br><small>Click the invoice link above to view the existing record.</small>").format(
+                    f"{supplier_name} ({doc.supplier})",
+                    doc.bill_no,
+                    fiscal_year.name,
+                    invoice_link
+                ),
+                indicator="red",
+                alert=True,
+                title=_("Duplicate Bill Number")
+            )
+            frappe.throw(
+                _("Duplicate Bill Number '{0}' not allowed for supplier '{1}' in fiscal year '{2}'. Please check invoice {3}.").format(
+                    doc.bill_no, supplier_name, fiscal_year.name, inv.name
+                )
+            )
+
+def set_taxable_amounts(doc, method):
+    side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+    vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+
+    item_vat = {}
+    vat_amount = 0.0
+    if vat_account:
+        for tax in doc.get("taxes") or []:
+            if tax.account_head != vat_account:
+                continue
+            vat_amount += flt(
+                tax.tax_amount_after_discount_amount
+                if tax.tax_amount_after_discount_amount is not None
+                else tax.tax_amount
+            )
+            detail = tax.item_wise_tax_detail
+            if isinstance(detail, str):
+                try:
+                    detail = json.loads(detail)
+                except (TypeError, ValueError):
+                    detail = {}
+            for item_key, rate_amount in (detail or {}).items():
+                if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
+                    item_vat[item_key] = item_vat.get(item_key, 0.0) + flt(rate_amount[1])
+
+    taxable_amount = non_taxable_amount = 0.0
+    for item in doc.get("items") or []:
+        amt = flt(item.get("net_amount"))
+        if item.get("is_nontaxable_item") or not flt(item_vat.get(item.get("item_code") or item.get("item_name"))):
+            non_taxable_amount += amt
+        else:
+            taxable_amount += amt
+
+    doc.taxable_amount = taxable_amount
+    doc.non_taxable_amount = non_taxable_amount
+    doc.vat_amount = vat_amount
+    doc.summary_grand_total = (
+        flt(doc.grand_total) if doc.get("disable_rounded_total") else (flt(doc.rounded_total) or flt(doc.grand_total))
+    )
+
+def get_vat_breakup(invoice_doctype, invoice_company_map):
+    """
+    Return per-invoice VAT amounts from the invoice's taxes table, considering only
+    the tax rows whose account head matches the VAT account configured for the
+    invoice's company in Nepal Compliance Settings.
+
+    Returns {invoice_name: {"item_vat": {item_code: amount}, "total_vat": float}}.
+    """
+    result = {name: {"item_vat": {}, "total_vat": 0.0} for name in invoice_company_map}
+    if not invoice_company_map:
+        return result
+
+    is_sales = invoice_doctype == "Sales Invoice"
+    side = "sales" if is_sales else "purchase"
+    taxes_doctype = "Sales Taxes and Charges" if is_sales else "Purchase Taxes and Charges"
+
+    configured = get_configured_vat_accounts()
+    missing = sorted({c for c in invoice_company_map.values() if c and not configured.get(c, {}).get(side)})
+    if missing:
+        frappe.msgprint(
+            _("VAT account is not configured for the following companies: {0}. VAT amounts will be shown as 0 in this report. Please set the {1} VAT Account under {2}.").format(
+                ", ".join(frappe.bold(c) for c in missing),
+                _("Sales") if is_sales else _("Purchase"),
+                get_link_to_form("Nepal Compliance Settings", "Nepal Compliance Settings", _("Nepal Compliance Settings > IRD VAT Accounts")),
+            ),
+            indicator="orange",
+            alert=True,
+        )
+
+    tax_rows = frappe.get_all(
+        taxes_doctype,
+        filters={"parent": ["in", list(invoice_company_map)], "parenttype": invoice_doctype},
+        fields=["parent", "account_head", "tax_amount", "tax_amount_after_discount_amount", "item_wise_tax_detail"],
+    )
+
+    for row in tax_rows:
+        vat_account = configured.get(invoice_company_map.get(row.parent), {}).get(side)
+        if not vat_account or row.account_head != vat_account:
+            continue
+
+        entry = result[row.parent]
+        entry["total_vat"] += flt(
+            row.tax_amount_after_discount_amount
+            if row.tax_amount_after_discount_amount is not None
+            else row.tax_amount
+        )
+        try:
+            detail = json.loads(row.item_wise_tax_detail) if row.item_wise_tax_detail else {}
+        except (TypeError, ValueError):
+            detail = {}
+        for item_key, rate_amount in detail.items():
+            if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
+                entry["item_vat"][item_key] = entry["item_vat"].get(item_key, 0.0) + flt(rate_amount[1])
+
+    return result
+
+def distribute_item_vat(items, item_vat_map):
+    """
+    Split item_code-level VAT (from item_wise_tax_detail) across individual item
+    rows, proportionally to each row's net_amount. The last row of each item code
+    takes the residual so the distributed amounts always sum back to the map total.
+
+    Returns a list of VAT amounts aligned with `items` by index.
+    """
+    groups = {}
+    for idx, item in enumerate(items):
+        key = item.get("item_code") or item.get("item_name")
+        groups.setdefault(key, []).append(idx)
+
+    row_vat = [0.0] * len(items)
+    for key, idxs in groups.items():
+        total_vat = flt(item_vat_map.get(key))
+        total_net = sum(flt(items[i].get("net_amount")) for i in idxs)
+        allocated = 0.0
+        for pos, i in enumerate(idxs):
+            if pos == len(idxs) - 1:
+                share = total_vat - allocated
+            else:
+                share = (total_vat * flt(items[i].get("net_amount")) / total_net) if total_net else 0.0
+            row_vat[i] = share
+            allocated += share
+
+    return row_vat


### PR DESCRIPTION
### Proposed change
Add VAT template helpers in `utils.py` and purchase-invoice client checks. The new whitelisted `is_purchase_invoice_attachment_required` includes a return type hint for **Frappe Linter**.

**Base:** `staging`  
**Size vs `staging`:** 2 files, +287 / −3 (290 lines).

Depends on VAT settings/account config (previous PR in this batch).

---

### Breaking change
- [x] ✅ No

---

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)

---

### PR Checklist
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the Contributing Guide and Code of Conduct.