### PR TITLE
fix(ird): match VAT rows in sales and purchase registers to configured accounts

### DIFF
--- a/nepal_compliance/nepal_compliance/report/purchase_register_ird/purchase_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_register_ird/purchase_register_ird.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt
 from frappe import _
+from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
 
 def execute(filters=None):
     columns = get_columns()
@@ -60,25 +61,28 @@ def get_data(filters):
     query = """
         SELECT
             pi.name as invoice, pi.bill_no, pi.bill_date, pi.customs_declaration_number, pi.rounded_total, pi.grand_total, pi.posting_date,
-            pi.supplier_name, pi.tax_id as invoice_pan, pi.total, pi.total_taxes_and_charges as total_tax, pi.supplier,
+            pi.supplier_name, pi.tax_id as invoice_pan, pi.total, pi.supplier, pi.company,
+            pi.taxable_amount as stored_taxable_amount, pi.item_vat_detail as stored_item_vat_detail,
             s.country as supplier_country, s.tax_id as supplier_tax_id
         FROM `tabPurchase Invoice` pi
         LEFT JOIN `tabSupplier` s ON pi.supplier = s.name
         WHERE {conditions}
         ORDER BY pi.posting_date
     """
-    
+
     query = query.replace("{conditions}", conditions_sql)
-    
+
     invoices = frappe.db.sql(query, values, as_dict=True)
     data = []
+
+    vat_breakup = get_vat_breakup("Purchase Invoice", {inv.invoice: inv.company for inv in invoices})
 
     invoice_names = [inv.invoice for inv in invoices]
     if invoice_names:
         all_items = frappe.get_all(
             "Purchase Invoice Item",
             filters={"parent": ["in", invoice_names]},
-            fields=["parent", "is_nontaxable_item", "net_amount", "amount", "asset_category", "item_tax_template"],
+            fields=["parent", "is_nontaxable_item", "net_amount", "amount", "asset_category", "item_code", "item_name"],
             limit_page_length=0
         )
         items_by_invoice = {}
@@ -94,40 +98,30 @@ def get_data(filters):
         pan = inv.invoice_pan or inv.supplier_tax_id
 
         tax_exempt = taxable_domestic_nc = taxable_import_nc = capital_taxable_amount = 0.0
+        tax_domestic_nc = tax_import_nc = tax_capital = 0.0
 
         items = items_by_invoice.get(inv.invoice, [])
+        item_vat_map, stored, breakup = resolve_report_vat_source(inv, vat_breakup)
+        row_vat = distribute_item_vat(items, item_vat_map)
 
-        for item in items:
-            amt = flt(item.get("net_amount"))
+        for item, item_vat in zip(items, row_vat, strict=True):
+            net = flt(item.get("net_amount"))
 
-            item_tax_template = item.get("item_tax_template")
-
-            is_nontaxable = (
-                item.get("is_nontaxable_item") or 
-                (flt(inv.total_tax) == 0 and not item_tax_template)
-            )
-
-            if is_nontaxable:
-                tax_exempt += amt
+            if is_exempt_report_item(item, item_vat, item_vat_map, stored, breakup):
+                tax_exempt += net
                 continue
 
+            amt = item_taxable_amount(item, item_vat, item_vat_map)
             if item.get("asset_category"):
                 capital_taxable_amount += amt
+                tax_capital += item_vat
             else:
                 if is_import:
                     taxable_import_nc += amt
+                    tax_import_nc += item_vat
                 else:
                     taxable_domestic_nc += amt
-
-        total_taxable = taxable_domestic_nc + taxable_import_nc + capital_taxable_amount
-        total_tax = flt(inv.total_tax)
-
-        if total_tax == 0 or total_taxable == 0:
-            tax_domestic_nc = tax_import_nc = tax_capital = 0
-        else:
-            tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax
-            tax_import_nc = (taxable_import_nc / total_taxable) * total_tax
-            tax_capital = (capital_taxable_amount / total_taxable) * total_tax
+                    tax_domestic_nc += item_vat
 
         data.append({
             "posting_date": inv.posting_date,

--- a/nepal_compliance/nepal_compliance/report/purchase_return_register_ird/purchase_return_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_return_register_ird/purchase_return_register_ird.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt
 from frappe import _
+from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
 
 def execute(filters=None):
     columns = get_columns()
@@ -62,61 +63,54 @@ def get_data(filters):
     query = """
         SELECT
             pi.name as invoice, pi.bill_no, pi.customs_declaration_number, pi.reason, pi.rounded_total, pi.grand_total, pi.posting_date, pi.supplier_name, pi.supplier, pi.tax_id as invoice_pan,
-            pi.total, pi.total_taxes_and_charges as total_tax
+            pi.total, pi.company, pi.taxable_amount as stored_taxable_amount, pi.item_vat_detail as stored_item_vat_detail
         FROM `tabPurchase Invoice` pi
         WHERE {conditions}
         ORDER BY pi.posting_date
     """
-    
+
     query = query.replace("{conditions}", conditions_sql)
 
     invoices = frappe.db.sql(query, values, as_dict=True)
     data = []
 
+    vat_breakup = get_vat_breakup("Purchase Invoice", {inv.invoice: inv.company for inv in invoices})
+
     for inv in invoices:
-        supplier_country = frappe.db.get_value("Supplier", inv.supplier_name, "country") or ""
+        supplier_country = frappe.db.get_value("Supplier", inv.supplier, "country") or ""
         is_import = supplier_country.strip().lower() != "nepal"
 
         pan = inv.invoice_pan or frappe.db.get_value("Supplier", inv.supplier, "tax_id")
 
         tax_exempt = taxable_domestic_nc = taxable_import_nc = capital_taxable_amount = 0.0
+        tax_domestic_nc = tax_import_nc = tax_capital = 0.0
 
         item_filters = {"parent": inv.invoice}
 
         items = frappe.get_all("Purchase Invoice Item", filters=item_filters,
-            fields=["is_nontaxable_item", "net_amount", "amount", "asset_category", "qty", "uom", "item_tax_template"])
+            fields=["is_nontaxable_item", "net_amount", "amount", "asset_category", "qty", "uom", "item_code", "item_name"])
 
-        for item in items:
-            amt = flt(item.get("net_amount"))
+        item_vat_map, stored, breakup = resolve_report_vat_source(inv, vat_breakup)
+        row_vat = distribute_item_vat(items, item_vat_map)
 
-            item_tax_template = item.get("item_tax_template")
+        for item, item_vat in zip(items, row_vat, strict=True):
+            net = flt(item.get("net_amount"))
 
-            is_nontaxable = (
-                item.get("is_nontaxable_item") or 
-                (flt(inv.total_tax) == 0 and not item_tax_template)
-            )
-
-            if is_nontaxable:
-                tax_exempt += amt
+            if is_exempt_report_item(item, item_vat, item_vat_map, stored, breakup):
+                tax_exempt += net
                 continue
 
+            amt = item_taxable_amount(item, item_vat, item_vat_map)
             if item.get("asset_category"):
                 capital_taxable_amount += amt
+                tax_capital += item_vat
             else:
                 if is_import:
                     taxable_import_nc += amt
+                    tax_import_nc += item_vat
                 else:
                     taxable_domestic_nc += amt
-
-        total_taxable = taxable_domestic_nc + taxable_import_nc + capital_taxable_amount
-        total_tax = flt(inv.total_tax)
-
-        if total_tax == 0 or total_taxable == 0:
-            tax_domestic_nc = tax_import_nc = tax_capital = 0
-        else:
-            tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax if total_taxable else 0
-            tax_import_nc = (taxable_import_nc / total_taxable) * total_tax if total_taxable else 0
-            tax_capital = (capital_taxable_amount / total_taxable) * total_tax if total_taxable else 0
+                    tax_domestic_nc += item_vat
 
         data.append({
             "posting_date": inv.posting_date,

--- a/nepal_compliance/nepal_compliance/report/sales_register_ird/sales_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/sales_register_ird/sales_register_ird.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt
 from frappe import _
+from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
 
 def execute(filters=None):
     columns = get_columns()
@@ -57,46 +58,50 @@ def get_data(filters):
 
     query = """
         SELECT
-            si.name as invoice, si.rounded_total, si.posting_date, si.customer_name, si.tax_id as invoice_pan, si.customer,
-            si.total, si.net_total, si.grand_total, si.total_taxes_and_charges as total_tax, si.customs_declaration_number, si.customs_declaration_date_bs
+            si.name as invoice, si.rounded_total, si.posting_date, si.customer_name, si.tax_id as invoice_pan, si.customer, si.company,
+            si.total, si.net_total, si.grand_total, si.customs_declaration_number, si.customs_declaration_date_bs,
+            si.taxable_amount as stored_taxable_amount, si.item_vat_detail as stored_item_vat_detail
         FROM `tabSales Invoice` si
         WHERE {conditions}
         ORDER BY si.posting_date
     """
-    
+
     query = query.replace("{conditions}", conditions_sql)
 
     invoices = frappe.db.sql(query, values, as_dict=True)
     data = []
 
+    vat_breakup = get_vat_breakup("Sales Invoice", {inv.invoice: inv.company for inv in invoices})
+
     for inv in invoices:
-        customer_country = frappe.db.get_value("Customer", inv.customer_name, "territory") or ""
+        customer_country = frappe.db.get_value("Customer", inv.customer, "territory") or ""
         is_export = customer_country.strip().lower() not in ("", "nepal")
 
         pan = inv.invoice_pan or frappe.db.get_value("Customer", inv.customer, "tax_id")
         
         tax_exempt = taxable_domestic_nc = taxable_import_nc = capital_taxable_amount = 0.0
+        tax_domestic_nc = 0.0
 
         item_filters = {"parent": inv.invoice}
-        
+
         items = frappe.get_all("Sales Invoice Item", filters=item_filters,
-            fields=["is_nontaxable_item", "net_amount", "amount", "item_code", "item_tax_template"])
-        
+            fields=["is_nontaxable_item", "net_amount", "amount", "item_code", "item_name"])
+
         item_codes = [item["item_code"] for item in items]
         asset_items = frappe.get_all("Item", filters={"item_code": ["in", item_codes], "is_fixed_asset": 1}, pluck="item_code")
-        
-        for item in items:
-            amt = flt(item.get("net_amount"))
 
-            item_tax_template = item.get("item_tax_template")
+        item_vat_map, stored, breakup = resolve_report_vat_source(inv, vat_breakup)
+        row_vat = distribute_item_vat(items, item_vat_map)
 
-            is_nontaxable = (
-                item.get("is_nontaxable_item") or (flt(inv.total_tax) == 0 and not item_tax_template))
+        for item, item_vat in zip(items, row_vat, strict=True):
+            net = flt(item.get("net_amount"))
 
-            if is_nontaxable:
-                tax_exempt += amt
+            is_exempt = is_exempt_report_item(item, item_vat, item_vat_map, stored, breakup)
+            if is_exempt and (item.get("is_nontaxable_item") or not is_export):
+                tax_exempt += net
                 continue
 
+            amt = item_taxable_amount(item, item_vat, item_vat_map)
             if item["item_code"] in asset_items:
                 capital_taxable_amount += amt
             else:
@@ -104,14 +109,7 @@ def get_data(filters):
                     taxable_import_nc += amt
                 else:
                     taxable_domestic_nc += amt
-
-        total_taxable = taxable_domestic_nc + taxable_import_nc + capital_taxable_amount
-        total_tax = flt(inv.total_tax)
-
-        if total_tax == 0 or total_taxable == 0:
-            tax_domestic_nc = tax_import_nc = tax_capital = 0
-        else:
-            tax_domestic_nc = (taxable_domestic_nc / total_taxable) * total_tax
+                    tax_domestic_nc += item_vat
 
         data.append({
             "posting_date": inv.posting_date,

--- a/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt
 from frappe import _
+from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
 
 def execute(filters=None):
     columns = get_columns()
@@ -63,65 +64,53 @@ def get_data(filters):
             si.customer_name,
             si.tax_id as pan,
             si.customer,
+            si.company,
             si.total,
-            si.total_taxes_and_charges as total_tax,
+            si.taxable_amount as stored_taxable_amount,
+            si.vat_amount as stored_vat_amount,
+            si.item_vat_detail as stored_item_vat_detail,
             si.posting_date
         FROM `tabSales Invoice` si
         WHERE {conditions}
         ORDER BY si.posting_date
     """
-    
+
     query = query.replace("{conditions}", conditions_sql)
 
     invoices = frappe.db.sql(query, values, as_dict=True)
     data = []
+
+    vat_breakup = get_vat_breakup("Sales Invoice", {inv.invoice: inv.company for inv in invoices})
 
     grand_qty = grand_total = grand_tax_exempt = grand_taxable = grand_tax = 0.0
 
     for inv in invoices:
         item_filters = {"parent": inv.invoice}
         items = frappe.get_all("Sales Invoice Item", filters=item_filters,
-            fields=["is_nontaxable_item", "net_amount", "amount", "item_code", "qty", "uom", "item_name", "item_tax_template"])
+            fields=["is_nontaxable_item", "net_amount", "amount", "item_code", "qty", "uom", "item_name"])
 
-        item_codes = [item["item_code"] for item in items]
-        asset_items = frappe.get_all("Item", filters={"item_code": ["in", item_codes], "is_fixed_asset": 1}, pluck="item_code")
+        item_vat_map, stored, breakup = resolve_report_vat_source(inv, vat_breakup)
+        total_vat = flt(inv.get("stored_vat_amount")) if stored else flt(breakup.get("total_vat"))
 
-        total_invoice = tax_exempt_total = taxable_total = total_qty = 0.0
-        taxable_item_net_amounts = []
+        tax_exempt_total = taxable_total = total_qty = 0.0
 
-        for item in items:
-            amt = flt(item.get("net_amount"))
-            item_tax_template = item.get("item_tax_template")
-            is_nontaxable = item.get("is_nontaxable_item") or (flt(inv.total_tax) == 0 and not item_tax_template)
+        row_vat = distribute_item_vat(items, item_vat_map)
+
+        for item, item_vat in zip(items, row_vat, strict=True):
+            net = flt(item.get("net_amount"))
             qty = flt(item.get("qty") or 0)
+            is_nontaxable = is_exempt_report_item(item, item_vat, item_vat_map, stored, breakup)
 
             total_qty += abs(qty)
 
-            if is_nontaxable or item["item_code"] in asset_items:
-                tax_exempt_total += amt
-            else:
-                taxable_total += amt
-                taxable_item_net_amounts.append((item, amt))
-
-        total_tax = flt(inv.total_tax)
-        for item, amt in taxable_item_net_amounts:
-            share = (amt / taxable_total) if taxable_total else 0
-            item["calculated_tax"] = share * total_tax
-
-        for item in items:
-            amt = flt(item.get("net_amount"))
-            qty = flt(item.get("qty") or 0)
-            item_tax_template = item.get("item_tax_template")
-            is_nontaxable = item.get("is_nontaxable_item") or (flt(inv.total_tax) == 0 and not item_tax_template)
-            is_fixed_asset = item["item_code"] in asset_items
-
             tax_exempt_item = taxable_amount_item = tax_amount_item = 0.0
-            if is_nontaxable or is_fixed_asset:
-                tax_exempt_item = amt
+            if is_nontaxable:
+                tax_exempt_item = net
+                tax_exempt_total += net
             else:
-                taxable_amount_item = amt
-                tax_amount_item = next(
-                    (i[0]["calculated_tax"] for i in taxable_item_net_amounts if i[0] == item), 0.0)
+                taxable_amount_item = item_taxable_amount(item, item_vat, item_vat_map)
+                tax_amount_item = item_vat
+                taxable_total += taxable_amount_item
 
             data.append({
                 "posting_date": inv.posting_date or "",
@@ -131,7 +120,7 @@ def get_data(filters):
                 "name": item.get("item_name") or item.get("item_code"),
                 "qty": abs(qty),
                 "uom": item.get("uom") or "",
-                "total": abs(flt(amt)),
+                "total": abs(flt(net)),
                 "tax_exempt": abs(flt(tax_exempt_item)),
                 "taxable_amount": abs(flt(taxable_amount_item)),
                 "tax_amount": abs(flt(tax_amount_item)),
@@ -148,14 +137,14 @@ def get_data(filters):
             "total": abs(flt(inv.rounded_total or inv.grand_total)),
             "tax_exempt": abs(flt(tax_exempt_total)),
             "taxable_amount": abs(flt(taxable_total)),
-            "tax_amount": abs(flt(total_tax))
+            "tax_amount": abs(total_vat)
         })
 
         grand_qty += abs(total_qty)
         grand_total += abs(flt(inv.rounded_total or inv.grand_total))
         grand_tax_exempt += abs(flt(tax_exempt_total))
         grand_taxable += abs(flt(taxable_total))
-        grand_tax += abs(flt(total_tax))
+        grand_tax += abs(total_vat)
 
     data.append({
         "posting_date": "",


### PR DESCRIPTION
### Proposed change
Update the four IRD VAT registers so tax rows are matched to the configured VAT accounts instead of brittle title/rate checks.

**Base:** `staging`  
**Size vs `staging`:** 4 files, +84 / −109 (193 lines).

---

### Breaking change
- [x] ✅ No

---

### Type of change
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)

---

### PR Checklist
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the Contributing Guide and Code of Conduct.