### PR TITLE
feat(vat): add property setter and taxable-summary backfill patches

### DIFF
--- a/nepal_compliance/overrides/asset_depreciation_schedule.py
+++ b/nepal_compliance/overrides/asset_depreciation_schedule.py
@@ -1,4 +1,3 @@
-import frappe
 from frappe.utils import add_days, cint, flt, getdate
 
 from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
@@ -27,6 +26,44 @@ def bs_aligned_depreciation_start(available_for_use_date, depreciation_start_dat
     return end_of(y, m)
 
 
+def is_bs_fiscal_period_end(ad_date, frequency):
+    """True when ad_date is the last day of a Nepali fiscal period for frequency."""
+    freq = max(cint(frequency), 1)
+    d = getdate(ad_date)
+    bs = ad_to_bs(d)
+    y, m = bs["year"], bs["month"]
+    if (m - 3) % freq != 0:
+        return False
+    return d == end_of(y, m)
+
+
+def resolve_bs_snap_anchor(posted, pending, available_for_use_date, frequency, opening_booked=0):
+    """Return (anchor_ad_date, skip_months) for snapping pending schedule rows.
+
+    Posted JE rows continue from the last posted date. Advance by a full
+    frequency only when that date is already a BS fiscal period end; otherwise
+    round up to the next period end so a mid-period posted date (e.g. Shrawan
+    with quarterly freq) still lands on Ashwin, not Poush.
+
+    Migrated assets with opening_number_of_booked_depreciations but no
+    journal_entry yet must skip those opening periods instead of re-anchoring
+    at available_for_use_date.
+    """
+    freq = max(cint(frequency), 1)
+    opening = cint(opening_booked)
+
+    if posted:
+        last = posted[-1].schedule_date
+        # Already on a period end → next period; else keep month and round up
+        skip = freq if is_bs_fiscal_period_end(last, freq) else 0
+        return last, skip
+    if opening and available_for_use_date:
+        return available_for_use_date, opening * freq
+    if available_for_use_date:
+        return available_for_use_date, 0
+    return pending[0].schedule_date, 0
+
+
 class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
     """Snap ERPNext depreciation rows onto BS fiscal period ends and fix amounts.
 
@@ -45,6 +82,7 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
         update_asset_finance_book_row=True,
         value_after_depreciation=None,
     ):
+        """Build the ERPNext schedule, then snap pending dates and amounts to BS periods."""
         self.align_depreciation_start_to_bs_period_end(asset_doc, row)
         super().make_depr_schedule(
             asset_doc,
@@ -53,8 +91,10 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
             update_asset_finance_book_row=update_asset_finance_book_row,
             value_after_depreciation=value_after_depreciation,
         )
-        self.snap_schedule_dates_to_bs_month_end(asset_doc)
-        self.recalculate_amounts_after_bs_snap(asset_doc, row)
+        self.snap_schedule_dates_to_bs_month_end(asset_doc, date_of_disposal=date_of_disposal)
+        self.recalculate_amounts_after_bs_snap(
+            asset_doc, row, date_of_disposal=date_of_disposal
+        )
         self.sync_finance_book_start_to_first_pending(
             row, update_asset_finance_book_row=update_asset_finance_book_row
         )
@@ -89,13 +129,17 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
         if getdate(row.depreciation_start_date) != aligned:
             row.depreciation_start_date = aligned
 
-    def snap_schedule_dates_to_bs_month_end(self, asset_doc=None):
+    def snap_schedule_dates_to_bs_month_end(self, asset_doc=None, date_of_disposal=None):
         """Move pending rows onto consecutive BS fiscal period ends.
 
-        Posted rows (with a journal entry) keep their historical dates. With no
+        Posted rows (with a journal entry) keep their historical dates. The first
+        pending date is the next BS fiscal period end after the last posted date
+        (without skipping a period when the posted date was mid-period). With no
         posted rows, the series starts at the next fiscal period end on or after
-        available_for_use (not ERPNext's first Gregorian date). Later rows
-        advance by frequency_of_depreciation months.
+        available_for_use, unless opening booked depreciations require skipping
+        those periods first. Later rows advance by frequency_of_depreciation months.
+        Rows never move past date_of_disposal: ERPNext places the terminal row at
+        the disposal date, and snapping must not push it beyond it.
         """
         rows = self.get("depreciation_schedule") or []
         if not rows:
@@ -107,13 +151,14 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
             return
 
         freq = cint(self.get("frequency_of_depreciation")) or 1
+        opening = cint(self.get("opening_number_of_booked_depreciations")) or cint(
+            (asset_doc or {}).get("opening_number_of_booked_depreciations")
+        )
+        available = asset_doc.get("available_for_use_date") if asset_doc else None
 
-        if posted:
-            anchor, skip = posted[-1].schedule_date, freq
-        elif asset_doc and asset_doc.get("available_for_use_date"):
-            anchor, skip = asset_doc.available_for_use_date, 0
-        else:
-            anchor, skip = pending[0].schedule_date, 0
+        anchor, skip = resolve_bs_snap_anchor(
+            posted, pending, available, freq, opening_booked=opening
+        )
 
         bs = ad_to_bs(getdate(anchor))
         y, m = advance(bs["year"], bs["month"], skip)
@@ -123,13 +168,35 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
             schedule_row.schedule_date = end_of(y, m)
             y, m = advance(y, m, freq)
 
-    def recalculate_amounts_after_bs_snap(self, asset_doc, row):
+        self._cap_pending_rows_at_disposal(pending, date_of_disposal)
+
+    def _cap_pending_rows_at_disposal(self, pending, date_of_disposal):
+        """Keep one terminal row on date_of_disposal; drop later pending rows."""
+        if not date_of_disposal:
+            return
+
+        disposal = getdate(date_of_disposal)
+        rows = self.get("depreciation_schedule") or []
+        drop = []
+        reached_disposal = False
+        for schedule_row in pending:
+            if reached_disposal:
+                drop.append(schedule_row)
+                continue
+            if getdate(schedule_row.schedule_date) >= disposal:
+                schedule_row.schedule_date = disposal
+                reached_disposal = True
+        for schedule_row in drop:
+            rows.remove(schedule_row)
+
+    def recalculate_amounts_after_bs_snap(self, asset_doc, row, date_of_disposal=None):
         """Rebuild SL/Manual amounts from BS-snapped dates.
 
         First pending row is pro-rated from the period start through its snapped
         schedule_date (capped at one full period); middle rows use the full
         period amount; the last pending row takes the residual so accumulated
-        depreciation hits salvage.
+        depreciation hits salvage, except on early disposal where that row is
+        pro-rated to date_of_disposal instead of absorbing remaining life.
         """
         if not asset_doc or not row:
             return
@@ -148,10 +215,23 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
             flt(asset_doc.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
         ) / flt(row.total_number_of_depreciations)
 
+        freq = cint(row.get("frequency_of_depreciation")) or cint(
+            self.get("frequency_of_depreciation")
+        ) or 1
+        opening = cint(self.get("opening_number_of_booked_depreciations")) or cint(
+            asset_doc.get("opening_number_of_booked_depreciations")
+        )
+
         posted = [r for r in rows if r.get("journal_entry")]
         if posted:
             accum = flt(posted[-1].accumulated_depreciation_amount)
             period_from = add_days(getdate(posted[-1].schedule_date), 1)
+        elif opening:
+            # First pending period begins the day after the last opening period end
+            accum = flt(self.opening_accumulated_depreciation)
+            first_bs = ad_to_bs(getdate(pending[0].schedule_date))
+            prev_y, prev_m = advance(first_bs["year"], first_bs["month"], -freq)
+            period_from = add_days(end_of(prev_y, prev_m), 1)
         else:
             accum = flt(self.opening_accumulated_depreciation)
             period_from = getdate(asset_doc.available_for_use_date)
@@ -159,17 +239,41 @@ class CustomAssetDepreciationSchedule(AssetDepreciationSchedule):
         target_total = flt(asset_doc.gross_purchase_amount) - flt(
             row.expected_value_after_useful_life
         )
+        total_depreciations = cint(row.total_number_of_depreciations)
+        booked = len(posted) + opening
 
         for idx, schedule_row in enumerate(pending):
             is_last = idx == len(pending) - 1
-            if idx == 0:
+            is_end_of_life = (booked + idx + 1) >= total_depreciations
+            is_early_disposal = (
+                bool(date_of_disposal)
+                and is_last
+                and not is_end_of_life
+                and getdate(schedule_row.schedule_date) == getdate(date_of_disposal)
+            )
+            if is_early_disposal:
+                # ERPNext booked this row as pro-rata to disposal. Do not replace
+                # it with the remaining useful-life residual.
+                from_date = (
+                    period_from
+                    if idx == 0
+                    else add_days(getdate(pending[idx - 1].schedule_date), 1)
+                )
+                amount, _days, _months = _get_pro_rata_amt(
+                    row, full_amt, from_date, schedule_row.schedule_date
+                )
+                amount = flt(min(amount, full_amt), precision)
+            elif is_last:
+                # Last pending row takes the residual so accumulated
+                # depreciation lands exactly on (gross - salvage), even when it
+                # is also the first/only pending row of a full useful life.
+                amount = flt(target_total - accum, precision)
+            elif idx == 0:
                 amount, _days, _months = _get_pro_rata_amt(
                     row, full_amt, period_from, schedule_row.schedule_date
                 )
                 # Never charge more than one frequency period in the first row
                 amount = flt(min(amount, full_amt), precision)
-            elif is_last:
-                amount = flt(target_total - accum, precision)
             else:
                 amount = flt(full_amt, precision)
 

--- a/nepal_compliance/patches.txt
+++ b/nepal_compliance/patches.txt
@@ -8,3 +8,5 @@ nepal_compliance.patches.update_income_tax_components
 # Patches added in this section will be executed after doctypes are migrated
 nepal_compliance.patches.v15.sync_salary_components
 nepal_compliance.patches.v15.hide_js_bs_fields
+nepal_compliance.patches.property_setters
+nepal_compliance.patches.backfill_taxable_summary

--- a/nepal_compliance/patches/backfill_taxable_summary.py
+++ b/nepal_compliance/patches/backfill_taxable_summary.py
@@ -1,0 +1,58 @@
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+def execute():
+    """Freeze taxable summary values on existing submitted invoices (idempotent).
+
+    Computes taxable_amount, non_taxable_amount, vat_amount and item_vat_detail
+    with the same logic the validate hook uses, writes them directly, and adds
+    a comment with the computed values on each updated invoice. Invoices whose
+    company has no VAT account configured are left empty so reports keep using
+    the live fallback and a later configuration can still fix them.
+
+    Selection is keyed on item_vat_detail (not taxable_amount) so invoices
+    created after the summary fields existed but before item_vat_detail was
+    introduced are backfilled too.
+    """
+    from nepal_compliance.utils import set_taxable_amounts
+
+    for doctype in ("Sales Invoice", "Purchase Invoice"):
+        names = frappe.get_all(
+            doctype,
+            filters={"docstatus": 1, "item_vat_detail": ["is", "not set"]},
+            pluck="name",
+        )
+        for count, name in enumerate(names, start=1):
+            doc = frappe.get_doc(doctype, name)
+            set_taxable_amounts(doc, None)
+            if doc.get("taxable_amount") is None:
+                continue
+
+            frappe.db.set_value(
+                doctype,
+                name,
+                {
+                    "taxable_amount": doc.taxable_amount,
+                    "non_taxable_amount": doc.non_taxable_amount,
+                    "vat_amount": doc.vat_amount,
+                    "summary_grand_total": doc.summary_grand_total,
+                    "item_vat_detail": doc.item_vat_detail,
+                },
+                update_modified=False,
+            )
+            doc.add_comment(
+                "Comment",
+                _(
+                    "Nepal Compliance: taxable summary computed for IRD reports. "
+                    "Taxable: {0}, Non-Taxable: {1}, VAT: {2}"
+                ).format(
+                    flt(doc.taxable_amount, 2),
+                    flt(doc.non_taxable_amount, 2),
+                    flt(doc.vat_amount, 2),
+                ),
+            )
+
+            if count % 100 == 0:
+                frappe.db.commit()

--- a/nepal_compliance/patches/property_setters.py
+++ b/nepal_compliance/patches/property_setters.py
@@ -1,0 +1,5 @@
+def execute():
+    """Create Nepal Compliance property setters on existing sites (idempotent)."""
+    from nepal_compliance.property_setter import create_property_setters
+
+    create_property_setters()


### PR DESCRIPTION
### Proposed change
Add install patches for property setters and taxable-summary backfill, plus remaining BS depreciation schedule fixes.

**Base:** `staging`  
**Size vs `staging`:** 4 files, +188 / −19 (207 lines).

Depends on VAT settings fields from the VAT account config PR.

---

### Breaking change
- [x] ✅ No

---

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)

---

### PR Checklist
- [x] ✅ All local tests passed with my changes.
- [x] 🔍 Checked for duplicate PRs with similar changes.
- [x] 📝 Followed the Contributing Guide and Code of Conduct.