### PR TITLE
feat(ird): add IRD purchase register Excel export including prior FY

### DIFF
--- a/nepal_compliance/nepal_compliance/report/purchase_register_ird/download_ird_format.py
+++ b/nepal_compliance/nepal_compliance/report/purchase_register_ird/download_ird_format.py
@@ -1,15 +1,20 @@
 # openpyxl 3.1.5 - MIT License, (c) 2024, Eric Gazoni, Charlie Clark, See License at https://pypi.org/project/openpyxl/
 
-import frappe
-from frappe import _
 import json
+
+import frappe
 import openpyxl
-from frappe.utils import get_site_path
-from openpyxl.styles import Alignment, Font, Border, Side
+from frappe import _
+from frappe.utils import get_site_path, getdate
+from openpyxl.styles import Alignment, Border, Font, Side
 from openpyxl.utils import get_column_letter
+
+from nepal_compliance.ird_filters import fiscal_year_ad_range, resolve_ird_fiscal_year_start
 from nepal_compliance.nepali_date_utils.utils import bs_date
 
+
 def convert_to_nepali_fy_format(year_start_date, year_end_date):
+    """Format an AD fiscal-year range using its approximate BS year labels."""
     try:
         start_year = year_start_date.year
         end_year = year_end_date.year
@@ -18,30 +23,33 @@ def convert_to_nepali_fy_format(year_start_date, year_end_date):
         nep_end = end_year + 57
 
         return f"{nep_start}/{str(nep_end)[-2:]}"
-    except Exception as e:
+    except Exception:
         return f"{year_start_date.year}-{year_end_date.year}"
 
-@frappe.whitelist()
-def generate_ird_purchase_register_excel():
-    from nepal_compliance.nepal_compliance.report.purchase_register_ird.purchase_register_ird import get_data
 
-    filters = frappe._dict(json.loads(frappe.form_dict.get("filters") or "{}"))
-    rows = get_data(filters)
+def _resolve_fiscal_year_bounds(filters, rows):
+    """Return ``(year_start_date, year_end_date)`` for the Excel header."""
+    fiscal_year = filters.get("fiscal_year")
+    if fiscal_year:
+        return fiscal_year_ad_range(fiscal_year)
 
-    if not rows:
-        frappe.throw(_("No data found for the selected filters."))
+    fy_start = resolve_ird_fiscal_year_start(filters)
+    fy_rows = frappe.db.get_all(
+        "Fiscal Year",
+        filters={"year_start_date": fy_start},
+        fields=["year_start_date", "year_end_date"],
+        limit=1,
+    )
+    if fy_rows:
+        return getdate(fy_rows[0].year_start_date), getdate(fy_rows[0].year_end_date)
 
-    company = filters.get("company")
-    company_info = frappe.get_doc("Company", company) if company else None
-    company_name = company_info.company_name if company_info else "Company Name"
-    # address = frappe.db.get_value("Address", {"is_your_company_address": 1}, "address_line1") or ""
-    pan = company_info.tax_id or "N/A"
-    invoice_name = frappe.db.get_value("Purchase Invoice", {"bill_no": rows[0].get("invoice")}, "name") or rows[0].get("invoice")
-    try:
-        invoice_doc = frappe.get_doc("Purchase Invoice", invoice_name)
-        posting_date = invoice_doc.posting_date
-    except frappe.DoesNotExistError:
-        frappe.throw(_("Purchase Invoice {0} not found").format(invoice_name))
+    posting_date = None
+    for row in rows:
+        if row.get("posting_date"):
+            posting_date = getdate(row["posting_date"])
+            break
+    if not posting_date:
+        frappe.throw(_("No Fiscal Year found for the selected filters."))
 
     fy_rows = frappe.db.get_all(
         "Fiscal Year",
@@ -49,17 +57,25 @@ def generate_ird_purchase_register_excel():
             "year_start_date": ["<=", posting_date],
             "year_end_date": [">=", posting_date],
         },
-        fields=["name", "year_start_date", "year_end_date"],
+        fields=["year_start_date", "year_end_date"],
         order_by="year_start_date desc",
         limit=1,
     )
     if not fy_rows:
         frappe.throw(_("No Fiscal Year found covering posting date {0}.").format(posting_date))
-    fy = fy_rows[0]
-    year_start_date = fy["year_start_date"]
-    year_end_date = fy["year_end_date"]
+    return getdate(fy_rows[0].year_start_date), getdate(fy_rows[0].year_end_date)
 
+
+def _build_purchase_register_workbook(rows, filters, *, title, subtitle, file_name):
+    """Build and save the IRD purchase register XLSX; return the public file URL."""
+    company = filters.get("company")
+    company_info = frappe.get_doc("Company", company) if company else None
+    company_name = company_info.company_name if company_info else "Company Name"
+    pan = (company_info.tax_id if company_info else None) or "N/A"
+
+    year_start_date, year_end_date = _resolve_fiscal_year_bounds(filters, rows)
     fiscal_year_nepali = convert_to_nepali_fy_format(year_start_date, year_end_date)
+
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "Purchase Register"
@@ -67,28 +83,34 @@ def generate_ird_purchase_register_excel():
     bold_center = Font(bold=True)
     center = Alignment(horizontal="center", vertical="center", wrap_text=True)
     border = Border(
-        left=Side(style="thin"), right=Side(style="thin"),
-        top=Side(style="thin"), bottom=Side(style="thin")
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
     )
 
     def format_cell(cell):
+        """Apply the shared heading style to one worksheet cell."""
         cell.alignment = center
         cell.font = bold_center
         cell.border = border
 
     ws.merge_cells("A1:M1")
-    ws["A1"] = f"खरिद खाता"
+    ws["A1"] = title
     ws["A1"].font = Font(bold=True, size=16)
 
     ws.merge_cells("A2:M2")
-    ws["A2"] = f"(नियम २३ को उपनियम (१) को खण्ड  (छ) संग सम्बन्धित )"
+    ws["A2"] = subtitle
     ws["A2"].font = Font(bold=False)
 
     ws.merge_cells("A3:M3")
     ws["A3"] = ""
 
     ws.merge_cells("A4:M4")
-    ws["A4"] = f"करदाता दर्ता नं (PAN): {pan}        करदाताको नाम: {company_name}         आर्थिक वर्ष: {fiscal_year_nepali}"
+    ws["A4"] = (
+        f"करदाता दर्ता नं (PAN): {pan}        करदाताको नाम: {company_name}         "
+        f"आर्थिक वर्ष: {fiscal_year_nepali}"
+    )
     ws["A4"].font = bold_center
     ws["A4"].alignment = Alignment(horizontal="left", vertical="center", wrap_text=True)
 
@@ -102,16 +124,16 @@ def generate_ird_purchase_register_excel():
         ("कर छुट हुने वस्तु वा सेवाको खरिद / पैठारी मूल्य (रु)", 1),
         ("करयोग्य खरिद (पूंजीगत बाहेक)", 2),
         ("करयोग्य पैठारी (पूंजीगत बाहेक)", 2),
-        ("पूंजीगत करयोग्य खरिद / पैठारी", 2)
+        ("पूंजीगत करयोग्य खरिद / पैठारी", 2),
     ]
 
     col = 1
-    for title, span in top_headers:
+    for header_title, span in top_headers:
         if span == 1:
             ws.merge_cells(start_row=5, start_column=col, end_row=6, end_column=col)
         else:
             ws.merge_cells(start_row=5, start_column=col, end_row=5, end_column=col + span - 1)
-        cell = ws.cell(row=5, column=col, value=title)
+        cell = ws.cell(row=5, column=col, value=header_title)
         format_cell(cell)
         col += span
 
@@ -128,7 +150,7 @@ def generate_ird_purchase_register_excel():
         10: "मूल्य (रु)",
         11: "कर (रु)",
         12: "मूल्य (रु)",
-        13: "कर (रु)"
+        13: "कर (रु)",
     }
 
     for col_num in range(1, 14):
@@ -163,7 +185,7 @@ def generate_ird_purchase_register_excel():
             inv.get("taxable_import_non_capital_amount"),
             inv.get("taxable_import_non_capital_tax"),
             inv.get("capital_taxable_amount"),
-            inv.get("capital_taxable_tax")
+            inv.get("capital_taxable_tax"),
         ]
 
         for col_idx, val in enumerate(row_data, 1):
@@ -171,7 +193,7 @@ def generate_ird_purchase_register_excel():
             cell.alignment = center
             cell.border = border
             if isinstance(val, (int, float)):
-                cell.number_format = '#,##0.00'
+                cell.number_format = "#,##0.00"
 
     total_row = len(rows) + 7
     ws.cell(row=total_row, column=1, value="Total")
@@ -183,11 +205,17 @@ def generate_ird_purchase_register_excel():
             continue
         col_letter = get_column_letter(col)
         col_total = f"=SUM({col_letter}7:{col_letter}{total_row - 1})"
-        if not any([coord in merged_range for merged_range in ws.merged_cells.ranges for coord in [ws.cell(row=total_row, column=col).coordinate]]):
+        if not any(
+            [
+                coord in merged_range
+                for merged_range in ws.merged_cells.ranges
+                for coord in [ws.cell(row=total_row, column=col).coordinate]
+            ]
+        ):
             cell = ws.cell(row=total_row, column=col, value=col_total)
             cell.border = border
             cell.alignment = center
-            cell.number_format = '#,##0.00'
+            cell.number_format = "#,##0.00"
 
     for row_idx in range(7, total_row):
         ws.cell(row=row_idx, column=5).font = Font(color="000000")
@@ -196,8 +224,55 @@ def generate_ird_purchase_register_excel():
         max_len = max(len(str(cell.value)) if cell.value else 0 for cell in col)
         ws.column_dimensions[get_column_letter(col[0].column)].width = max_len + 4
 
-    file_name = "IRD_Purchase_Register.xlsx"
     path = get_site_path("public", "files", file_name)
     wb.save(path)
-
     return f"/files/{file_name}"
+
+
+@frappe.whitelist()
+def generate_ird_purchase_register_excel() -> str:
+    """Generate the IRD-eligible Purchase Register as an XLSX download."""
+    from nepal_compliance.nepal_compliance.report.purchase_register_ird.purchase_register_ird import (
+        get_data,
+    )
+
+    filters = frappe._dict(json.loads(frappe.form_dict.get("filters") or "{}"))
+    rows = get_data(filters, bucket="eligible")
+
+    if not rows:
+        frappe.throw(_("No data found for the selected filters."))
+
+    return _build_purchase_register_workbook(
+        rows,
+        filters,
+        title="खरिद खाता",
+        subtitle="(नियम २३ को उपनियम (१) को खण्ड  (छ) संग सम्बन्धित )",
+        file_name="IRD_Purchase_Register.xlsx",
+    )
+
+
+@frappe.whitelist()
+def generate_ird_prior_fy_purchase_register_excel() -> str:
+    """Generate Prior Fiscal Year Purchases as an XLSX download for the filters."""
+    from nepal_compliance.nepal_compliance.report.purchase_register_ird.purchase_register_ird import (
+        get_data,
+    )
+
+    filters = frappe._dict(json.loads(frappe.form_dict.get("filters") or "{}"))
+    rows = get_data(filters, bucket="prior_fy")
+
+    if not rows:
+        frappe.throw(
+            _("No Prior Fiscal Year Purchases found for the selected filters.")
+        )
+
+    return _build_purchase_register_workbook(
+        rows,
+        filters,
+        title="गत आर्थिक वर्षका खरिद",
+        subtitle=_(
+            "Prior Fiscal Year Purchases (supplier bill date before selected fiscal year; "
+            "excluded from IRD-submittable register)"
+        ),
+        file_name="IRD_Prior_FY_Purchase_Register.xlsx",
+    )


### PR DESCRIPTION
### Proposed change
Extend purchase register IRD Excel export, including prior-FY download. Whitelisted exporters have return type hints for Frappe Linter.

**Base:** `staging`  
**Size vs `staging`:** +117 / −42 (159 lines).

### Breaking change
- [x] ✅ No

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)