### PR TITLE
fix(ird): align sales and sales-return register VAT totals with displayed rows

### DIFF
--- a/nepal_compliance/nepal_compliance/report/sales_register_ird/sales_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/sales_register_ird/sales_register_ird.py
@@ -2,19 +2,75 @@
 # For license information, please see LICENSE at the root of this repository
 
 import frappe
-from frappe.utils import flt
 from frappe import _
-from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
+from frappe.utils import flt
+
+from nepal_compliance.ird_country import is_foreign_country, resolve_ird_country
+from nepal_compliance.ird_filters import (
+    apply_ird_posting_date_filters,
+    invoice_link_fields,
+)
+from nepal_compliance.utils import (
+    distribute_item_vat,
+    get_vat_breakup,
+    invoice_ird_total,
+    is_exempt_report_item,
+    item_taxable_amount,
+    resolve_report_vat_source,
+)
+
+
+def get_sales_register_summary(rows):
+    """Build colored summary cards for the Sales Register."""
+    rows = rows or []
+    total = len(rows)
+    tax_exempt = sum(1 for r in rows if flt(r.get("tax_exempt")) > 0)
+    taxable = sum(1 for r in rows if flt(r.get("taxable_amount")) > 0)
+    export = sum(
+        1 for r in rows if flt(r.get("Value of Exported Goods or Services")) > 0
+    )
+
+    return [
+        {
+            "value": total,
+            "label": _("Total Sales"),
+            "datatype": "Int",
+            "indicator": "Blue",
+        },
+        {
+            "value": tax_exempt,
+            "label": _("कर छुटको बिक्री"),
+            "datatype": "Int",
+            "indicator": "Grey",
+        },
+        {
+            "value": taxable,
+            "label": _("करयोग्य बिक्री"),
+            "datatype": "Int",
+            "indicator": "Blue",
+        },
+        {
+            "value": export,
+            "label": _("निकासी"),
+            "datatype": "Int",
+            "indicator": "Orange",
+        },
+    ]
+
 
 def execute(filters=None):
+    """Run the IRD Sales Register and return columns, rows, and summary."""
     columns = get_columns()
     data = get_data(filters)
-    return columns, data
+    summary = get_sales_register_summary(data)
+    return columns, data, None, None, summary
+
 
 def get_columns():
+    """Column definitions for the IRD Sales Register."""
     return [
         {"label": _("मिति"), "fieldname": "posting_date", "fieldtype": "Date", "width": 150},
-        {"label": _("बीजक नं."), "fieldname": "invoice", "fieldtype": "Link", "options": "Sales Invoice", "width": 200},
+        {"label": _("बीजक नं."), "fieldname": "invoice", "fieldtype": "Data", "width": 200},
         {"label": _("खरिदकर्ताको नाम"), "fieldname": "customer_name", "fieldtype": "Data", "width": 160},
         {"label": _("खरिदकर्ताको स्थायी लेखा नम्बर"), "fieldname": "pan", "fieldtype": "Data", "width": 120},
         {"label": _("जम्मा बिक्री / निकासी (रु)"), "fieldname": "total", "fieldtype": "Float", "width": 120},
@@ -27,7 +83,10 @@ def get_columns():
         {"label": _("निकासी प्रज्ञापनपत्र मिति"), "fieldname": "Export Declaration Date", "fieldtype": "Data", "width": 140},
     ]
 
+
 def get_data(filters):
+    """Build sales register rows from submitted invoices in the filter range."""
+    filters = filters or {}
     conditions = ["si.docstatus = 1 and si.is_return = 0"]
     values = {}
 
@@ -43,25 +102,21 @@ def get_data(filters):
         conditions.append("si.name = %(document_number)s")
         values["document_number"] = filters.get("document_number")
 
-    if filters.get("from_nepali_date") and filters.get("to_nepali_date"):
-        conditions.append("si.posting_date BETWEEN %(from)s AND %(to)s")
-        values["from"] = filters.get("from_nepali_date")
-        values["to"] = filters.get("to_nepali_date")
-    elif filters.get("from_nepali_date"):
-        conditions.append("si.posting_date >= %(from)s")
-        values["from"] = filters.get("from_nepali_date")
-    elif filters.get("to_nepali_date"):
-        conditions.append("si.posting_date <= %(to)s")
-        values["to"] = filters.get("to_nepali_date")
+    apply_ird_posting_date_filters(filters, conditions, values, "si.posting_date")
 
     conditions_sql = " AND ".join(conditions)
 
     query = """
         SELECT
             si.name as invoice, si.rounded_total, si.posting_date, si.customer_name, si.tax_id as invoice_pan, si.customer, si.company,
-            si.total, si.net_total, si.grand_total, si.customs_declaration_number, si.customs_declaration_date_bs,
-            si.taxable_amount as stored_taxable_amount, si.item_vat_detail as stored_item_vat_detail
+            si.total, si.net_total, si.grand_total, si.summary_grand_total, si.customs_declaration_number, si.customs_declaration_date_bs,
+            si.taxable_amount as stored_taxable_amount, si.item_vat_detail as stored_item_vat_detail,
+            si.ird_party_country as stored_party_country,
+            billing_address.country as address_country,
+            c.tax_id as customer_tax_id
         FROM `tabSales Invoice` si
+        LEFT JOIN `tabCustomer` c ON si.customer = c.name
+        LEFT JOIN `tabAddress` billing_address ON billing_address.name = si.customer_address
         WHERE {conditions}
         ORDER BY si.posting_date
     """
@@ -74,11 +129,11 @@ def get_data(filters):
     vat_breakup = get_vat_breakup("Sales Invoice", {inv.invoice: inv.company for inv in invoices})
 
     for inv in invoices:
-        customer_country = frappe.db.get_value("Customer", inv.customer, "territory") or ""
-        is_export = customer_country.strip().lower() not in ("", "nepal")
+        customer_country = resolve_ird_country(inv.stored_party_country, inv.address_country)
+        is_export = is_foreign_country(customer_country)
 
-        pan = inv.invoice_pan or frappe.db.get_value("Customer", inv.customer, "tax_id")
-        
+        pan = inv.invoice_pan or inv.customer_tax_id
+
         tax_exempt = taxable_domestic_nc = taxable_import_nc = capital_taxable_amount = 0.0
         tax_domestic_nc = 0.0
 
@@ -114,9 +169,10 @@ def get_data(filters):
         data.append({
             "posting_date": inv.posting_date,
             "invoice": inv.invoice,
+            **invoice_link_fields("Sales Invoice", inv.invoice),
             "customer_name": inv.customer_name,
             "pan": pan,
-            "total": inv.rounded_total or inv.grand_total,
+            "total": invoice_ird_total(inv),
             "tax_exempt": tax_exempt,
             "taxable_amount": taxable_domestic_nc,
             "tax_amount": tax_domestic_nc,

--- a/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
+++ b/nepal_compliance/nepal_compliance/report/sales_return_register_ird/sales_return_register_ird.py
@@ -2,19 +2,36 @@
 # For license information, please see LICENSE at the root of this repository
 
 import frappe
-from frappe.utils import flt
 from frappe import _
-from nepal_compliance.utils import distribute_item_vat, get_vat_breakup, is_exempt_report_item, item_taxable_amount, resolve_report_vat_source
+from frappe.utils import flt
+
+from nepal_compliance.ird_filters import (
+    apply_ird_posting_date_filters,
+    invoice_link_fields,
+)
+from nepal_compliance.utils import (
+    distribute_item_vat,
+    get_vat_breakup,
+    invoice_ird_total,
+    is_exempt_report_item,
+    item_taxable_amount,
+    resolve_report_vat_source,
+)
+
+ITEM_QUERY_BATCH_SIZE = 500
+
 
 def execute(filters=None):
+    """Run the IRD Sales Return Register and return columns plus rows."""
     columns = get_columns()
     data = get_data(filters or {})
     return columns, data
 
 def get_columns():
+    """Column definitions for the IRD Sales Return Register."""
     return [
         {"label": _("मिति"), "fieldname": "posting_date", "fieldtype": "Date", "width": 150},
-        {"label": _("बीजक नं."), "fieldname": "invoice", "fieldtype": "Link", "options": "Sales Invoice", "width": 200},
+        {"label": _("बीजक नं."), "fieldname": "invoice", "fieldtype": "Data", "width": 200},
         {"label": _("खरिदकर्ताको नाम"), "fieldname": "customer_name", "fieldtype": "Data", "width": 160},
         {"label": _("खरिदकर्ताको स्थायी लेखा नम्बर"), "fieldname": "pan", "fieldtype": "Data", "width": 120},
         {"label": _("वस्तु वा सेवाको नाम"), "fieldname": "name", "fieldtype": "Data", "width": 200},
@@ -27,6 +44,8 @@ def get_columns():
     ]
 
 def get_data(filters):
+    """Build sales return register rows from submitted returns in the filter range."""
+    filters = filters or {}
     conditions = ["si.docstatus = 1", "si.is_return = 1"]
     values = {}
 
@@ -42,16 +61,7 @@ def get_data(filters):
         conditions.append("si.name = %(return_invoice)s")
         values["return_invoice"] = filters.get("return_invoice")
 
-    if filters.get("from_nepali_date") and filters.get("to_nepali_date"):
-        conditions.append("si.posting_date BETWEEN %(from)s AND %(to)s")
-        values["from"] = filters.get("from_nepali_date")
-        values["to"] = filters.get("to_nepali_date")
-    elif filters.get("from_nepali_date"):
-        conditions.append("si.posting_date >= %(from)s")
-        values["from"] = filters.get("from_nepali_date")
-    elif filters.get("to_nepali_date"):
-        conditions.append("si.posting_date <= %(to)s")
-        values["to"] = filters.get("to_nepali_date")
+    apply_ird_posting_date_filters(filters, conditions, values, "si.posting_date")
 
     conditions_sql = " AND ".join(conditions)
 
@@ -60,6 +70,7 @@ def get_data(filters):
             si.name as invoice,
             si.rounded_total,
             si.grand_total,
+            si.summary_grand_total,
             si.posting_date,
             si.customer_name,
             si.tax_id as pan,
@@ -69,8 +80,9 @@ def get_data(filters):
             si.taxable_amount as stored_taxable_amount,
             si.vat_amount as stored_vat_amount,
             si.item_vat_detail as stored_item_vat_detail,
-            si.posting_date
+            c.tax_id as customer_tax_id
         FROM `tabSales Invoice` si
+        LEFT JOIN `tabCustomer` c ON si.customer = c.name
         WHERE {conditions}
         ORDER BY si.posting_date
     """
@@ -82,17 +94,27 @@ def get_data(filters):
 
     vat_breakup = get_vat_breakup("Sales Invoice", {inv.invoice: inv.company for inv in invoices})
 
+    invoice_names = [inv.invoice for inv in invoices]
+    items_by_invoice = {}
+    for start in range(0, len(invoice_names), ITEM_QUERY_BATCH_SIZE):
+        batch_names = invoice_names[start:start + ITEM_QUERY_BATCH_SIZE]
+        batch_items = frappe.get_all(
+            "Sales Invoice Item",
+            filters={"parent": ["in", batch_names]},
+            fields=["parent", "is_nontaxable_item", "net_amount", "amount", "item_code", "qty", "uom", "item_name"],
+            limit_page_length=0,
+        )
+        for item in batch_items:
+            items_by_invoice.setdefault(item.parent, []).append(item)
+
     grand_qty = grand_total = grand_tax_exempt = grand_taxable = grand_tax = 0.0
 
     for inv in invoices:
-        item_filters = {"parent": inv.invoice}
-        items = frappe.get_all("Sales Invoice Item", filters=item_filters,
-            fields=["is_nontaxable_item", "net_amount", "amount", "item_code", "qty", "uom", "item_name"])
+        items = items_by_invoice.get(inv.invoice, [])
 
         item_vat_map, stored, breakup = resolve_report_vat_source(inv, vat_breakup)
-        total_vat = flt(inv.get("stored_vat_amount")) if stored else flt(breakup.get("total_vat"))
 
-        tax_exempt_total = taxable_total = total_qty = 0.0
+        tax_exempt_total = taxable_total = total_qty = tax_total = 0.0
 
         row_vat = distribute_item_vat(items, item_vat_map)
 
@@ -111,12 +133,14 @@ def get_data(filters):
                 taxable_amount_item = item_taxable_amount(item, item_vat, item_vat_map)
                 tax_amount_item = item_vat
                 taxable_total += taxable_amount_item
+                tax_total += tax_amount_item
 
             data.append({
                 "posting_date": inv.posting_date or "",
                 "invoice": inv.invoice,
+                **invoice_link_fields("Sales Invoice", inv.invoice),
                 "customer_name": inv.customer_name,
-                "pan": inv.pan or frappe.db.get_value("Customer", inv.customer, "tax_id"),
+                "pan": inv.pan or inv.customer_tax_id,
                 "name": item.get("item_name") or item.get("item_code"),
                 "qty": abs(qty),
                 "uom": item.get("uom") or "",
@@ -129,26 +153,28 @@ def get_data(filters):
         data.append({
             "posting_date": "",
             "invoice": "",
+            **invoice_link_fields("", ""),
             "customer_name": "जम्मा",
             "pan": "",
             "name": "",
             "qty": abs(total_qty),
             "uom": "",
-            "total": abs(flt(inv.rounded_total or inv.grand_total)),
+            "total": abs(flt(invoice_ird_total(inv))),
             "tax_exempt": abs(flt(tax_exempt_total)),
             "taxable_amount": abs(flt(taxable_total)),
-            "tax_amount": abs(total_vat)
+            "tax_amount": abs(flt(tax_total)),
         })
 
         grand_qty += abs(total_qty)
-        grand_total += abs(flt(inv.rounded_total or inv.grand_total))
+        grand_total += abs(flt(invoice_ird_total(inv)))
         grand_tax_exempt += abs(flt(tax_exempt_total))
         grand_taxable += abs(flt(taxable_total))
-        grand_tax += abs(total_vat)
+        grand_tax += abs(flt(tax_total))
 
     data.append({
         "posting_date": "",
         "invoice": "",
+        **invoice_link_fields("", ""),
         "customer_name": "कुल जम्मा",
         "pan": "",
         "name": "",


### PR DESCRIPTION
### Proposed change
Align Sales Register IRD and Sales Return Register IRD totals with displayed item VAT.

**Base:** `staging`  
**Size vs `staging`:** +127 / −45 (172 lines).

### Breaking change
- [x] ✅ No

### Type of change
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)