### PR TITLE
feat(ird): add IRD country classification helper and tests

### DIFF
--- a/nepal_compliance/ird_country.py
+++ b/nepal_compliance/ird_country.py
@@ -1,0 +1,37 @@
+import frappe
+
+DEFAULT_COUNTRY = "Nepal"
+
+
+def resolve_ird_country(stored_country=None, address_country=None) -> str:
+    """Return the frozen invoice country, linked-address country, or Nepal."""
+    for country in (stored_country, address_country):
+        if country and str(country).strip():
+            return str(country).strip()
+    return DEFAULT_COUNTRY
+
+
+def is_foreign_country(country) -> bool:
+    """Return whether a normalized country should be treated as foreign."""
+    return resolve_ird_country(country).casefold() != DEFAULT_COUNTRY.casefold()
+
+
+def set_invoice_party_country(doc, method=None) -> None:
+    """Freeze the selected customer or supplier address country on a draft invoice."""
+    if doc.doctype == "Sales Invoice":
+        address_name = doc.get("customer_address")
+    elif doc.doctype == "Purchase Invoice":
+        address_name = doc.get("supplier_address")
+    else:
+        return
+
+    # Submitted invoices can only be changed through IRD Country Correction.
+    if doc.docstatus:
+        return
+
+    address_country = (
+        frappe.db.get_value("Address", address_name, "country")
+        if address_name
+        else None
+    )
+    doc.ird_party_country = resolve_ird_country(address_country=address_country)

--- a/nepal_compliance/nepal_compliance/doctype/ird_country_correction/test_ird_country_correction.py
+++ b/nepal_compliance/nepal_compliance/doctype/ird_country_correction/test_ird_country_correction.py
@@ -1,0 +1,110 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nepal_compliance.nepal_compliance.doctype.ird_country_correction import (
+    ird_country_correction as correction_module,
+)
+from nepal_compliance.nepal_compliance.doctype.ird_country_correction.ird_country_correction import (
+    IRDCountryCorrection,
+    get_invoice_country,
+    get_permitted_invoice,
+)
+
+
+class TestIRDCountryCorrection(unittest.TestCase):
+    @patch.object(correction_module, "frappe")
+    def test_invoice_snapshot_takes_precedence_over_address(self, frappe_mock):
+        invoice = MagicMock(doctype="Sales Invoice")
+        invoice.get.side_effect = {
+            "customer_address": "ADDR-1",
+            "ird_party_country": "India",
+        }.get
+        frappe_mock.db.get_value.return_value = "Nepal"
+
+        self.assertEqual(get_invoice_country(invoice), "India")
+
+    @patch.object(correction_module, "frappe")
+    def test_legacy_invoice_uses_selected_address(self, frappe_mock):
+        invoice = MagicMock(doctype="Purchase Invoice")
+        invoice.get.side_effect = {
+            "supplier_address": "ADDR-2",
+            "ird_party_country": None,
+        }.get
+        frappe_mock.db.get_value.return_value = "China"
+
+        self.assertEqual(get_invoice_country(invoice), "China")
+
+    @patch.object(correction_module, "frappe")
+    def test_source_invoice_submit_permission_is_required(self, frappe_mock):
+        invoice = MagicMock(docstatus=1)
+        frappe_mock.get_doc.return_value = invoice
+        frappe_mock.has_permission.return_value = False
+        frappe_mock.PermissionError = PermissionError
+        frappe_mock.throw.side_effect = PermissionError
+
+        with self.assertRaises(PermissionError):
+            get_permitted_invoice("Sales Invoice", "SINV-1")
+
+        invoice.check_permission.assert_called_once_with("read")
+        frappe_mock.has_permission.assert_called_once_with(
+            "Sales Invoice", "submit", doc=invoice
+        )
+
+    @patch.object(correction_module, "get_link_to_form", return_value="CORRECTION-LINK")
+    @patch.object(correction_module, "now_datetime", return_value="2026-08-30 09:00:00")
+    @patch.object(correction_module, "get_invoice_country", return_value="Nepal")
+    @patch.object(correction_module, "get_permitted_invoice")
+    @patch.object(correction_module, "frappe")
+    def test_submit_updates_snapshot_and_adds_audit_comment(
+        self,
+        frappe_mock,
+        get_invoice,
+        _get_country,
+        _now,
+        _get_link,
+    ):
+        invoice = MagicMock()
+        get_invoice.return_value = invoice
+        frappe_mock.session.user = "manager@example.com"
+        correction = SimpleNamespace(
+            invoice_type="Sales Invoice",
+            invoice="SINV-1",
+            current_country="Nepal",
+            new_country="India",
+            reason="Wrong address <script>",
+            doctype="IRD Country Correction",
+            name="IRD-COUNTRY-2026-00001",
+        )
+
+        IRDCountryCorrection.before_submit(correction)
+
+        frappe_mock.db.set_value.assert_called_once_with(
+            "Sales Invoice", "SINV-1", "ird_party_country", "India"
+        )
+        comment = invoice.add_comment.call_args.args[1]
+        self.assertIn("Nepal", comment)
+        self.assertIn("India", comment)
+        self.assertIn("manager@example.com", comment)
+        self.assertIn("Wrong address &lt;script&gt;", comment)
+        self.assertNotIn("Wrong address <script>", comment)
+        self.assertEqual(correction.corrected_by, "manager@example.com")
+
+    @patch.object(correction_module, "get_invoice_country", return_value="India")
+    @patch.object(correction_module, "get_permitted_invoice", return_value=MagicMock())
+    @patch.object(correction_module, "frappe")
+    def test_submit_rejects_stale_current_country(
+        self, frappe_mock, _get_invoice, _get_country
+    ):
+        frappe_mock.throw.side_effect = RuntimeError
+        correction = SimpleNamespace(
+            invoice_type="Sales Invoice",
+            invoice="SINV-1",
+            current_country="Nepal",
+            new_country="China",
+        )
+
+        with self.assertRaises(RuntimeError):
+            IRDCountryCorrection.before_submit(correction)
+
+        frappe_mock.db.set_value.assert_not_called()

--- a/nepal_compliance/test/test_ird_country.py
+++ b/nepal_compliance/test/test_ird_country.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from nepal_compliance.ird_country import (
+    is_foreign_country,
+    resolve_ird_country,
+    set_invoice_party_country,
+)
+
+
+class TestIRDCountry(unittest.TestCase):
+    def test_nepal_and_missing_country_are_domestic(self):
+        self.assertFalse(is_foreign_country(" Nepal "))
+        self.assertFalse(is_foreign_country("NEPAL"))
+        self.assertFalse(is_foreign_country(None))
+
+    def test_non_nepal_country_is_foreign(self):
+        self.assertTrue(is_foreign_country("India"))
+        self.assertTrue(is_foreign_country("China"))
+
+    def test_snapshot_takes_precedence_over_current_address(self):
+        self.assertEqual(resolve_ird_country("India", "Nepal"), "India")
+
+    def test_address_country_is_used_for_legacy_invoice(self):
+        self.assertEqual(resolve_ird_country(None, " India "), "India")
+        self.assertEqual(resolve_ird_country(None, None), "Nepal")
+
+    @patch("nepal_compliance.ird_country.frappe")
+    def test_sales_invoice_snapshots_customer_address_country(self, frappe_mock):
+        get_value = frappe_mock.db.get_value
+        get_value.return_value = "India"
+        doc = frappe._dict(
+            doctype="Sales Invoice",
+            docstatus=0,
+            customer_address="Customer Billing",
+        )
+
+        set_invoice_party_country(doc)
+
+        get_value.assert_called_once_with("Address", "Customer Billing", "country")
+        self.assertEqual(doc.ird_party_country, "India")
+
+    @patch("nepal_compliance.ird_country.frappe")
+    def test_purchase_invoice_snapshots_supplier_address_country(self, frappe_mock):
+        get_value = frappe_mock.db.get_value
+        get_value.return_value = "China"
+        doc = frappe._dict(
+            doctype="Purchase Invoice",
+            docstatus=0,
+            supplier_address="Supplier Billing",
+        )
+
+        set_invoice_party_country(doc)
+
+        get_value.assert_called_once_with("Address", "Supplier Billing", "country")
+        self.assertEqual(doc.ird_party_country, "China")
+
+    @patch("nepal_compliance.ird_country.frappe")
+    def test_missing_address_defaults_to_nepal(self, frappe_mock):
+        get_value = frappe_mock.db.get_value
+        doc = frappe._dict(doctype="Sales Invoice", docstatus=0)
+
+        set_invoice_party_country(doc)
+
+        get_value.assert_not_called()
+        self.assertEqual(doc.ird_party_country, "Nepal")
+
+    @patch("nepal_compliance.ird_country.frappe")
+    def test_submitted_invoice_keeps_existing_snapshot(self, frappe_mock):
+        get_value = frappe_mock.db.get_value
+        doc = frappe._dict(
+            doctype="Sales Invoice",
+            docstatus=1,
+            customer_address="Customer Billing",
+            ird_party_country="India",
+        )
+
+        set_invoice_party_country(doc)
+
+        get_value.assert_not_called()
+        self.assertEqual(doc.ird_party_country, "India")
+
+    @patch("nepal_compliance.ird_country.frappe")
+    def test_submitted_invoice_without_snapshot_is_not_changed_directly(
+        self, frappe_mock
+    ):
+        get_value = frappe_mock.db.get_value
+        doc = frappe._dict(
+            doctype="Purchase Invoice",
+            docstatus=1,
+            supplier_address="Supplier Billing",
+        )
+
+        set_invoice_party_country(doc)
+
+        get_value.assert_not_called()
+        self.assertIsNone(doc.ird_party_country)


### PR DESCRIPTION
### Proposed change
Add `ird_country.py` and tests for India vs third-country classification.

**Base:** `staging`  
**Size vs `staging`:** +246 (246 lines).

Depends on the IRD Country Correction DocType PR.

### Breaking change
- [x] ✅ No

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)