### PR TITLE
feat(vat): add PAN bill VAT handling and tests

### DIFF
--- a/nepal_compliance/default_tax_template.py
+++ b/nepal_compliance/default_tax_template.py
@@ -1,0 +1,27 @@
+import frappe
+
+
+DEFAULT_PURCHASE_TAX_TEMPLATE = "Nepal Tax - YT"
+
+
+def set_default_purchase_tax_template():
+    """Make Nepal Tax - YT the default Purchase Taxes and Charges Template."""
+    if not frappe.db.exists(
+        "Purchase Taxes and Charges Template",
+        {"name": DEFAULT_PURCHASE_TAX_TEMPLATE, "disabled": 0},
+    ):
+        return
+
+    template = frappe.get_doc(
+        "Purchase Taxes and Charges Template", DEFAULT_PURCHASE_TAX_TEMPLATE
+    )
+    if template.is_default:
+        return
+    if frappe.db.exists(
+        "Purchase Taxes and Charges Template",
+        {"company": template.company, "is_default": 1, "disabled": 0},
+    ):
+        return
+
+    template.is_default = 1
+    template.save(ignore_permissions=True)

--- a/nepal_compliance/overrides/purchase_invoice.py
+++ b/nepal_compliance/overrides/purchase_invoice.py
@@ -1,0 +1,30 @@
+from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import PurchaseInvoice
+from erpnext.controllers.taxes_and_totals import (
+    calculate_taxes_and_totals as ERPNextTaxesAndTotals,
+)
+
+from nepal_compliance.utils import (
+    apply_pan_bill_vat_override,
+    apply_taxable_amount_as_tds_base,
+)
+
+
+class NepalPurchaseTaxesAndTotals(ERPNextTaxesAndTotals):
+    def update_item_tax_map(self):
+        """Load normal item taxes, then suppress only configured VAT for PAN bills."""
+        super().update_item_tax_map()
+        apply_pan_bill_vat_override(self.doc)
+
+
+class CustomPurchaseInvoice(PurchaseInvoice):
+    def calculate_taxes_and_totals(self):
+        NepalPurchaseTaxesAndTotals(self)
+
+    def set_tax_withholding(self):
+        """Use Taxable Amount as the TDS base when the withholding category requires it."""
+        apply_taxable_amount_as_tds_base(self)
+        super().set_tax_withholding()
+        # ERPNext recalculates tax_withholding_net_total from all Apply TDS
+        # items after inserting the Actual TDS row. Restore the configured
+        # taxable base so the invoice records the amount actually used.
+        apply_taxable_amount_as_tds_base(self)

--- a/nepal_compliance/patches/add_pan_bill_and_default_purchase_tax.py
+++ b/nepal_compliance/patches/add_pan_bill_and_default_purchase_tax.py
@@ -1,0 +1,7 @@
+from nepal_compliance.custom_field import create_custom_fields
+from nepal_compliance.default_tax_template import set_default_purchase_tax_template
+
+
+def execute():
+    create_custom_fields(quiet=True)
+    set_default_purchase_tax_template()

--- a/nepal_compliance/public/js/purchase_invoice.js
+++ b/nepal_compliance/public/js/purchase_invoice.js
@@ -5,11 +5,39 @@ frappe.require([
 ], function () {
 
     frappe.ui.form.on("Purchase Invoice", {
-        refresh(frm) {
+        async refresh(frm) {
             if (typeof handle_send_email === "function") {
                 handle_send_email(frm, "Purchase Invoice");
+            }
+            await mark_submit_mandatory_fields(frm);
+        },
+        async before_submit(frm) {
+            if (frappe.flags.in_import || frappe.flags.in_install || frappe.flags.in_migrate) {
+                return;
+            }
+            const requirements = await get_purchase_invoice_requirements();
+            if (requirements.bill_date && !frm.doc.bill_date) {
+                frappe.throw(__("Please fill in the <b>Supplier Invoice Date</b> before submitting."));
             }
         }
     });
 
 });
+
+// Visual-only "required" asterisk for fields enforced at submit time,
+// so drafts remain saveable without them.
+async function get_purchase_invoice_requirements() {
+    const response = await frappe.call("nepal_compliance.utils.get_purchase_invoice_requirements");
+    return response.message || {};
+}
+
+async function mark_submit_mandatory_fields(frm) {
+    frm.get_field("bill_no")?.$wrapper.find(".control-label").addClass("reqd");
+    const requirements = await get_purchase_invoice_requirements();
+    frm.get_field("bill_date")
+        ?.$wrapper.find(".control-label")
+        .toggleClass("reqd", !!cint(requirements.bill_date));
+    frm.get_field("attach_purchase_invoice")
+        ?.$wrapper.find(".control-label")
+        .toggleClass("reqd", !!cint(requirements.attachment));
+}

--- a/nepal_compliance/test/test_pan_bill.py
+++ b/nepal_compliance/test/test_pan_bill.py
@@ -1,0 +1,98 @@
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+import frappe
+
+from nepal_compliance import default_tax_template, utils
+
+
+class TestPanBill(unittest.TestCase):
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_pan_bill_suppresses_only_configured_vat(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        item = frappe._dict(
+            item_tax_rate=json.dumps(
+                {"VAT Payable": 13, "VAT Receivable": 13, "Excise": 5}
+            )
+        )
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            is_pan_or_abbreviated_bill=1,
+            items=[item],
+        )
+
+        utils.apply_pan_bill_vat_override(invoice)
+
+        self.assertEqual(
+            json.loads(item.item_tax_rate),
+            {"Excise": 5, "VAT Receivable": 0},
+        )
+
+    @patch("nepal_compliance.utils.set_taxable_amounts")
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_pan_bill_tds_uses_bill_total(self, configured, set_summary):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        set_summary.side_effect = lambda doc, _method: doc.update(
+            {"summary_grand_total": 1000}
+        )
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            is_pan_or_abbreviated_bill=1,
+        )
+
+        base, reason = utils.get_purchase_taxable_tds_base(invoice)
+
+        self.assertEqual(base, 1000)
+        self.assertIsNone(reason)
+
+    @patch("nepal_compliance.default_tax_template.frappe.get_doc")
+    @patch("nepal_compliance.default_tax_template.frappe.db.exists")
+    def test_company_nepal_tax_becomes_purchase_default(self, exists, get_doc):
+        exists.side_effect = [True, None]
+        template = frappe._dict(
+            is_default=0,
+            company="Yarsa Tech Pvt. Ltd.",
+        )
+        template.save = Mock()
+        get_doc.return_value = template
+
+        default_tax_template.set_default_purchase_tax_template()
+
+        self.assertEqual(
+            exists.call_args_list[1].args,
+            (
+                "Purchase Taxes and Charges Template",
+                {
+                    "company": "Yarsa Tech Pvt. Ltd.",
+                    "is_default": 1,
+                    "disabled": 0,
+                },
+            ),
+        )
+        template.save.assert_called_once_with(ignore_permissions=True)
+
+    @patch("nepal_compliance.default_tax_template.frappe.get_doc")
+    @patch("nepal_compliance.default_tax_template.frappe.db.exists")
+    def test_existing_purchase_default_is_preserved(self, exists, get_doc):
+        exists.side_effect = [True, "Existing Purchase Tax - YT"]
+        template = frappe._dict(
+            is_default=0,
+            company="Yarsa Tech Pvt. Ltd.",
+        )
+        template.save = Mock()
+        get_doc.return_value = template
+
+        default_tax_template.set_default_purchase_tax_template()
+
+        template.save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Proposed change
Add PAN bill VAT tests, default tax template, and purchase invoice override.

**Base:** `staging`  
**Size vs `staging`:** +176 / −16 (192 lines).

### Breaking change
- [x] ✅ No

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)