### PR TITLE
feat(ird): wire IRD country fields, hooks, workspace, and calendar assets

### DIFF
--- a/nepal_compliance/custom_field.py
+++ b/nepal_compliance/custom_field.py
@@ -1,13 +1,25 @@
 import frappe
-from dataclasses import fields
 from frappe import _
+from frappe.utils import cint
 
 
-def create_custom_fields():
+def create_custom_fields(quiet=False):
+    """Create Nepal Compliance custom fields on standard doctypes (idempotent)."""
     custom_fields = {
         "Company": [
             {"fieldname": "logo_for_printing", "label": "Logo For Printing", "fieldtype": "Attach", "insert_after": "parent_company"},
             {"fieldname": "company_vat_number", "label": "Vat/Pan Number", "fieldtype": "Data", "insert_after": "default_holiday_list", "allow_on_submit": 1}
+        ],
+        "Tax Withholding Category": [
+            {
+                "fieldname": "calculate_tds_on_taxable_amount",
+                "label": "Calculate TDS on Taxable Amount",
+                "fieldtype": "Check",
+                "insert_after": "round_off_tax_amount",
+                "default": "1",
+                "permlevel": 1,
+                "description": "If checked, Purchase Invoice TDS is calculated on Taxable Amount instead of item net total. Nepal default. Only Accounts Manager can change this.",
+            }
         ],
         "Item": [
             {"fieldname": "is_nontaxable_item", "label": "Is Non-Taxable Item", "fieldtype": "Check", "insert_after": "is_stock_item"},
@@ -81,18 +93,26 @@ def create_custom_fields():
         ],  
         "Purchase Invoice":[
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date", "allow_on_submit": 1},
+            {"fieldname": "ird_party_country", "label": "IRD Party Country", "fieldtype": "Link", "options": "Country", "insert_after": "supplier_address", "hidden": 1, "read_only": 1},
             {"fieldname": "vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "supplier", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "customer_vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "qr_code", "label": "QR Code", "fieldtype": "Attach", "insert_after": "customer_vat_number", "hidden": 1, "allow_on_submit": 1},
             {"fieldname": "reason", "label": "Reason For Return", "fieldtype": "Data", "insert_after": "customer_vat_number", "depends_on": "eval:doc.is_return == 1", "mandatory_depends_on": "eval:doc.is_return == 1"},
             {"fieldname": "customs_declaration_number", "label": "Customs Declaration Number", "fieldtype": "Data", "insert_after": "bill_no"},
-            {"fieldname": "attach_purchase_invoice", "label": "Attach Purchase Invoice", "fieldtype": "Attach", "insert_after": "bill_date", "allow_on_submit": 1},
+            {
+                "fieldname": "is_pan_or_abbreviated_bill",
+                "label": "Is PAN/Abbreviated Bill",
+                "fieldtype": "Check",
+                "insert_after": "bill_date",
+                "description": "Enable this when the supplier issued a PAN or abbreviated bill on which input VAT must not be claimed. Example: an item of Rs 1,000 normally adds Rs 130 VAT; when checked, VAT is Rs 0. If TDS is enabled, it is calculated on the Bill Total.",
+            },
+            {"fieldname": "attach_purchase_invoice", "label": "Attach Purchase Invoice", "fieldtype": "Attach", "insert_after": "is_pan_or_abbreviated_bill", "allow_on_submit": 1},
             {"fieldname": "taxable_summary_section", "label": "Taxable Summary", "fieldtype": "Section Break", "insert_after": "taxes"},
             {"fieldname": "taxable_amount", "label": "Taxable Amount", "fieldtype": "Currency", "insert_after": "taxable_summary_section", "read_only": 1, "allow_on_submit": 1},
             {"fieldname": "non_taxable_amount", "label": "Non-Taxable Amount", "fieldtype": "Currency", "insert_after": "taxable_amount", "read_only": 1, "allow_on_submit": 1},
             {"fieldname": "taxable_summary_col_break", "fieldtype": "Column Break", "insert_after": "non_taxable_amount"},
             {"fieldname": "vat_amount", "label": "VAT Amount", "fieldtype": "Currency", "insert_after": "taxable_summary_col_break", "read_only": 1, "allow_on_submit": 1},
-            {"fieldname": "summary_grand_total", "label": "Grand Total", "fieldtype": "Currency", "insert_after": "vat_amount", "read_only": 1, "allow_on_submit": 1},
+            {"fieldname": "summary_grand_total", "label": "Bill Total", "fieldtype": "Currency", "insert_after": "vat_amount", "read_only": 1, "allow_on_submit": 1},
             {"fieldname": "item_vat_detail", "label": "Item VAT Detail", "fieldtype": "Long Text", "insert_after": "summary_grand_total", "hidden": 1, "read_only": 1, "allow_on_submit": 1}
         ],
         "Sales Order":[
@@ -100,6 +120,7 @@ def create_custom_fields():
         ],
         "Sales Invoice": [
             {"fieldname": "nepali_date", "label": "Nepali Date", "fieldtype": "Data", "insert_after": "posting_date", "allow_on_submit": 1},
+            {"fieldname": "ird_party_country", "label": "IRD Party Country", "fieldtype": "Link", "options": "Country", "insert_after": "customer_address", "hidden": 1, "read_only": 1},
             {"fieldname": "vat_number", "label": "Customer VAT/PAN", "fieldtype": "Data", "insert_after": "customer", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "supplier_vat_number", "label": "Supplier VAT/PAN", "fieldtype": "Data", "insert_after": "vat_number", "in_list_view": 1, "allow_on_submit": 1},
             {"fieldname": "qr_code", "label": "QR Code", "fieldtype": "Attach", "insert_after": "supplier_vat_number", "hidden": 1, "allow_on_submit": 1},
@@ -114,7 +135,7 @@ def create_custom_fields():
             {"fieldname": "non_taxable_amount", "label": "Non-Taxable Amount", "fieldtype": "Currency", "insert_after": "taxable_amount", "read_only": 1, "allow_on_submit": 1},
             {"fieldname": "taxable_summary_col_break", "fieldtype": "Column Break", "insert_after": "non_taxable_amount"},
             {"fieldname": "vat_amount", "label": "VAT Amount", "fieldtype": "Currency", "insert_after": "taxable_summary_col_break", "read_only": 1, "allow_on_submit": 1},
-            {"fieldname": "summary_grand_total", "label": "Grand Total", "fieldtype": "Currency", "insert_after": "vat_amount", "read_only": 1, "allow_on_submit": 1},
+            {"fieldname": "summary_grand_total", "label": "Bill Total", "fieldtype": "Currency", "insert_after": "vat_amount", "read_only": 1, "allow_on_submit": 1},
             {"fieldname": "item_vat_detail", "label": "Item VAT Detail", "fieldtype": "Long Text", "insert_after": "summary_grand_total", "hidden": 1, "read_only": 1, "allow_on_submit": 1}
         ],
         "Delivery Note":[
@@ -328,7 +349,10 @@ def create_custom_fields():
 
     for doctype_name, fields in custom_fields.items():
         for field in fields:
-            if not frappe.db.exists("Custom Field", {"dt": doctype_name, "fieldname": field["fieldname"]}):
+            existing_name = frappe.db.exists(
+                "Custom Field", {"dt": doctype_name, "fieldname": field["fieldname"]}
+            )
+            if not existing_name:
                 custom_field = frappe.get_doc({
                     "doctype": "Custom Field",
                     "dt": doctype_name,
@@ -336,11 +360,29 @@ def create_custom_fields():
                     **field
                 })
                 custom_field.save()
-                frappe.msgprint(_(f"Custom field '{field.get('label') or field['fieldname']}' added successfully to {doctype_name}!"))
+                if not quiet:
+                    frappe.msgprint(
+                        _("Custom field '{0}' added successfully to {1}!").format(
+                            field.get("label") or field["fieldname"], doctype_name
+                        )
+                    )
                 created_fields.append({"dt": doctype_name, "fieldname": field["fieldname"]})
             else:
-                frappe.msgprint(_(f"Field '{field.get('label') or field['fieldname']}' already exists in {doctype_name}."))
+                updates = {}
+                new_label = field.get("label")
+                if new_label and frappe.db.get_value("Custom Field", existing_name, "label") != new_label:
+                    updates["label"] = new_label
+                if "permlevel" in field:
+                    current = cint(frappe.db.get_value("Custom Field", existing_name, "permlevel"))
+                    if current != cint(field["permlevel"]):
+                        updates["permlevel"] = cint(field["permlevel"])
+                if updates:
+                    frappe.db.set_value("Custom Field", existing_name, updates)
+                elif not quiet:
+                    frappe.msgprint(
+                        _("Field '{0}' already exists in {1}.").format(
+                            field.get("label") or field["fieldname"], doctype_name
+                        )
+                    )
 
-    return created_fields  
-
-create_custom_fields()
+    return created_fields

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -37,6 +37,8 @@ app_include_js = [
     "/assets/nepal_compliance/js/filter_patch.js",
     "/assets/nepal_compliance/js/formatter.js",
     "/assets/nepal_compliance/js/report_filter.js",
+    "/assets/nepal_compliance/js/ird_bs_dates.js",
+    "/assets/nepal_compliance/js/ird_month_picker.js",
     "/assets/nepal_compliance/js/ird_register.js?v=ird-prior-fy-5",
     "/assets/nepal_compliance/js/icon_patch.js",
     "/assets/nepal_compliance/js/employee_benefit_claim.js"]

--- a/nepal_compliance/hooks.py
+++ b/nepal_compliance/hooks.py
@@ -26,7 +26,7 @@ add_to_apps_screen = [
 # include js, css files in header of desk.html
 app_include_css = [
     "/assets/nepal_compliance/css/nepali_calendar.css",
-    "/assets/nepal_compliance/css/date.css"]
+    "/assets/nepal_compliance/css/date.css?v=ird-prior-fy-7"]
 
 app_include_js = [
     "https://unpkg.com/react@18.3.1/umd/react.production.min.js",
@@ -37,6 +37,7 @@ app_include_js = [
     "/assets/nepal_compliance/js/filter_patch.js",
     "/assets/nepal_compliance/js/formatter.js",
     "/assets/nepal_compliance/js/report_filter.js",
+    "/assets/nepal_compliance/js/ird_register.js?v=ird-prior-fy-5",
     "/assets/nepal_compliance/js/icon_patch.js",
     "/assets/nepal_compliance/js/employee_benefit_claim.js"]
 
@@ -167,6 +168,7 @@ override_doctype_class = {  # nosemgrep: frappe-semgrep-rules.rules.override-doc
     "Payroll Entry": "nepal_compliance.overrides.salary_slip.CustomPayrollEntry",
     "Leave Policy Assignment": "nepal_compliance.custom_code.leave_allocation.monthly_leave_bs.LeavePolicyAssignment",
     "Asset Depreciation Schedule": "nepal_compliance.overrides.asset_depreciation_schedule.CustomAssetDepreciationSchedule",
+    "Purchase Invoice": "nepal_compliance.overrides.purchase_invoice.CustomPurchaseInvoice",
 }
 
 # Document Events
@@ -176,20 +178,41 @@ doc_events = {
     "*": {
         "validate": "nepal_compliance.backdated_doctype_restriction.validate_backdate_and_sequence"
     },
+    "Item": {
+        "validate": "nepal_compliance.utils.ensure_side_specific_item_tax_mappings",
+    },
+    "Item Group": {
+        "validate": "nepal_compliance.utils.ensure_side_specific_item_tax_mappings",
+    },
     "Purchase Invoice" : {
         "on_trash": "nepal_compliance.utils.prevent_invoice_deletion",
         "before_insert": "nepal_compliance.utils.set_vat_numbers",
-        "before_validate": "nepal_compliance.utils.apply_vat_exemption_for_nontaxable_items",
-        "validate": ["nepal_compliance.utils.set_taxable_amounts", "nepal_compliance.utils.validate_duplicate_bill_no"],
+        "before_validate": [
+            "nepal_compliance.utils.apply_side_specific_vat_template",
+            "nepal_compliance.utils.apply_vat_exemption_for_nontaxable_items",
+        ],
+        "validate": [
+            "nepal_compliance.ird_country.set_invoice_party_country",
+            "nepal_compliance.utils.set_taxable_amounts",
+            "nepal_compliance.utils.validate_duplicate_bill_no",
+        ],
         "on_submit": "nepal_compliance.qr_code.create_qr_code",
         "before_submit": ["nepal_compliance.utils.bill_no_required", "nepal_compliance.utils.require_purchase_invoice_attachment"]
     },
     "Sales Invoice" : {
         "autoname": "nepal_compliance.utils.custom_autoname",
         "before_insert": "nepal_compliance.utils.set_vat_numbers",
-        "before_validate": "nepal_compliance.utils.apply_vat_exemption_for_nontaxable_items",
+        "before_validate": [
+            "nepal_compliance.utils.apply_side_specific_vat_template",
+            "nepal_compliance.utils.apply_vat_exemption_for_nontaxable_items",
+        ],
         "on_submit": "nepal_compliance.cbms_api.post_sales_invoice_or_return_to_cbms",
-        "validate": ["nepal_compliance.qr_code.create_qr_code", "nepal_compliance.utils.load_nepali_date", "nepal_compliance.utils.set_taxable_amounts"]
+        "validate": [
+            "nepal_compliance.ird_country.set_invoice_party_country",
+            "nepal_compliance.qr_code.create_qr_code",
+            "nepal_compliance.utils.load_nepali_date",
+            "nepal_compliance.utils.set_taxable_amounts",
+        ]
     },
     "Sales Order" : {
         "validate": "nepal_compliance.utils.load_nepali_date"

--- a/nepal_compliance/install.py
+++ b/nepal_compliance/install.py
@@ -7,11 +7,15 @@ from nepal_compliance.custom_code.payroll.payroll_settings import modify_email_s
 from nepal_compliance.custom_code.leave_type.leave_type import setup_default_leave_types
 from nepal_compliance.custom_code.print_settings import print_cancelled_invoice
 from nepal_compliance.custom_code.payroll.salary_component import create_multiple_salary_components
+from nepal_compliance.default_tax_template import set_default_purchase_tax_template
+from nepal_compliance.tds_withholding import setup_tds_on_taxable_amount_permissions
 
 def install():
     """Create custom fields, property setters, and default Nepal Compliance data."""
     create_custom_fields()
     create_property_setters()
+    set_default_purchase_tax_template()
+    setup_tds_on_taxable_amount_permissions()
     create_multiple_salary_components()
     create_income_tax_slabs_for_all_companies()
     modify_email_salary_slip_default()

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.json
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.json
@@ -21,6 +21,7 @@
   "vat_accounts_section",
   "vat_accounts",
   "purchase_tab",
+  "require_supplier_bill_date",
   "require_purchase_invoice_attachment",
   "enable_duplicate_bill_no_check"
  ],
@@ -117,6 +118,13 @@
    "fieldname": "purchase_tab",
    "fieldtype": "Tab Break",
    "label": "Purchase"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, a Purchase Invoice cannot be submitted without the supplier's invoice date.",
+   "fieldname": "require_supplier_bill_date",
+   "fieldtype": "Check",
+   "label": "Make Supplier Invoice Date Mandatory"
   },
   {
    "default": "0",

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.py
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.py
@@ -3,9 +3,16 @@
 
 import frappe
 from frappe import _
+from frappe.core.doctype.user_permission.user_permission import get_user_permissions
 from frappe.model.document import Document
 from frappe.utils import flt
 import redis
+
+from nepal_compliance.utils import (
+    get_or_create_vat_exempt_template,
+    sync_managed_vat_taxable_templates,
+)
+
 
 class NepalComplianceSettings(Document):
     def validate(self):
@@ -24,6 +31,7 @@ class NepalComplianceSettings(Document):
             row.validate()
 
     def on_update(self):
+        """Clear cached date settings and sync VAT accounts into company tax templates."""
         cache = frappe.cache()
         for key in (
             "nepal_compliance:bs_enabled",
@@ -36,7 +44,9 @@ class NepalComplianceSettings(Document):
         self.sync_vat_accounts_to_templates()
 
     def sync_vat_accounts_to_templates(self):
+        """Repoint VAT rows in each company's tax templates to the configured accounts."""
         updated = []
+        skipped = []
         for row in self.get("vat_accounts") or []:
             if not row.company:
                 continue
@@ -46,9 +56,19 @@ class NepalComplianceSettings(Document):
             ):
                 if not account:
                     continue
-                for template_name in frappe.get_all(doctype, filters={"company": row.company}, pluck="name"):
-                    if self._repoint_template_vat_rows(doctype, template_name, account):
+                for template_name in frappe.get_list(
+                    doctype, filters={"company": row.company}, pluck="name"
+                ):
+                    result = self._repoint_template_vat_rows(
+                        doctype, template_name, account, row.company
+                    )
+                    if result == "updated":
                         updated.append(template_name)
+                    elif result == "skipped":
+                        skipped.append(template_name)
+                side = "sales" if doctype.startswith("Sales") else "purchase"
+                sync_managed_vat_taxable_templates(row.company, account, side)
+                get_or_create_vat_exempt_template(row.company, account, side)
         if updated:
             frappe.msgprint(
                 _("VAT rows in the following tax templates were updated to the configured accounts: {0}").format(
@@ -57,13 +77,67 @@ class NepalComplianceSettings(Document):
                 indicator="green",
                 alert=True,
             )
+        if skipped:
+            frappe.msgprint(
+                _(
+                    "{0} tax template(s) were not updated because you do not have write access for their company."
+                ).format(len(skipped)),
+                indicator="orange",
+                alert=True,
+            )
 
     @staticmethod
-    def _repoint_template_vat_rows(doctype, template_name, vat_account):
-        template = frappe.get_doc(doctype, template_name)
-        vat_rows = [tax for tax in template.taxes if tax.account_head and "vat" in tax.account_head.lower()]
-        if not vat_rows:
+    def _is_vat_tax_row(tax, vat_account):
+        """True when the tax row is the configured VAT ledger or a named VAT row."""
+        if not tax.account_head:
             return False
+        if tax.account_head == vat_account:
+            return True
+        return "vat" in tax.account_head.lower()
+
+    @staticmethod
+    def _user_may_write_company_template(template, company):
+        """Whether this user may save a tax template for the configured company.
+
+        Direct DocType write is preferred. Otherwise a company-scoped delegation
+        applies: the user can write Nepal Compliance Settings, the template
+        belongs to the VAT-account row's company, and User Permissions (when
+        present) include that company.
+        """
+        if frappe.has_permission(template.doctype, "write", doc=template):
+            return "direct"
+        if not frappe.has_permission("Nepal Compliance Settings", "write"):
+            return None
+        if getattr(template, "company", None) != company:
+            return None
+        company_perms = get_user_permissions().get("Company") or []
+        if company_perms:
+            allowed = {perm.get("doc") for perm in company_perms}
+            if template.company not in allowed:
+                return None
+        return "delegated"
+
+    @classmethod
+    def _save_company_template(cls, template, company):
+        """Save a tax template using write permission or company-scoped delegation."""
+        mode = cls._user_may_write_company_template(template, company)
+        if mode == "direct":
+            template.save()
+            return True
+        if mode == "delegated":
+            # Company-scoped delegation: Settings writers may update templates
+            # only for companies they just configured, subject to User Permissions.
+            template.save(ignore_permissions=True)
+            return True
+        return False
+
+    @classmethod
+    def _repoint_template_vat_rows(cls, doctype, template_name, vat_account, company):
+        """Update matching VAT rows on one template. Returns updated/skipped/unchanged."""
+        template = frappe.get_doc(doctype, template_name)
+        vat_rows = [tax for tax in template.taxes if cls._is_vat_tax_row(tax, vat_account)]
+        if not vat_rows:
+            return "unchanged"
 
         changed = False
         primary = next((tax for tax in vat_rows if tax.account_head == vat_account), vat_rows[0])
@@ -86,6 +160,8 @@ class NepalComplianceSettings(Document):
                 template.taxes.remove(tax)
                 changed = True
 
-        if changed:
-            template.save(ignore_permissions=True)
-        return changed
+        if not changed:
+            return "unchanged"
+        if not cls._save_company_template(template, company):
+            return "skipped"
+        return "updated"

--- a/nepal_compliance/nepal_compliance/workspace/nepal_compliance/nepal_compliance.json
+++ b/nepal_compliance/nepal_compliance/workspace/nepal_compliance/nepal_compliance.json
@@ -174,7 +174,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Audit Reports",
-   "link_count": 2,
+   "link_count": 3,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -186,6 +186,16 @@
    "link_count": 0,
    "link_to": "Audit Trail",
    "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "IRD Country Correction",
+   "link_count": 0,
+   "link_to": "IRD Country Correction",
+   "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
   },

--- a/nepal_compliance/patches/sync_bill_total_label.py
+++ b/nepal_compliance/patches/sync_bill_total_label.py
@@ -1,0 +1,5 @@
+def execute():
+    """Sync Taxable Summary Bill Total label on existing Sales/Purchase Invoice fields."""
+    from nepal_compliance.custom_field import create_custom_fields
+
+    create_custom_fields(quiet=True)

--- a/nepal_compliance/patches/sync_ird_party_country_fields.py
+++ b/nepal_compliance/patches/sync_ird_party_country_fields.py
@@ -1,0 +1,5 @@
+def execute():
+    """Create the invoice country snapshot fields on existing sites."""
+    from nepal_compliance.custom_field import create_custom_fields
+
+    create_custom_fields(quiet=True)


### PR DESCRIPTION
### Proposed change
Wire custom fields, hooks (including the three IRD JS assets), workspace, settings, and sync patches.

**Base:** `staging`  
**Size vs `staging`:** +150 / −75 (225 lines).

Depends on IRD JS helper PRs (#324–#326) and the country DocType PR.

### Breaking change
- [x] ✅ No

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)