### PR TITLE
feat(vat): add item VAT helpers and PAN bill VAT override

### DIFF
--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -1,3 +1,4 @@
+import json
 import frappe
 from frappe import _
 from frappe.utils import flt
@@ -121,3 +122,116 @@ def check_app_permission():
         return True
 
     return False
+
+def apply_pan_bill_vat_override(doc):
+    """Set configured VAT to zero for a PAN/abbreviated Purchase Invoice."""
+    if doc.doctype != "Purchase Invoice" or not doc.get(
+        "is_pan_or_abbreviated_bill"
+    ):
+        return
+
+    accounts = get_configured_vat_accounts().get(doc.company, {})
+    vat_account = accounts.get("purchase")
+    if not vat_account:
+        frappe.throw(
+            _(
+                "Purchase VAT Account is required in Nepal Compliance Settings "
+                "before a PAN/Abbreviated Bill can suppress VAT."
+            ),
+            title=_("Purchase VAT Account Not Configured"),
+        )
+
+    configured_vat_accounts = {
+        account for account in accounts.values() if account
+    }
+    for item in doc.get("items") or []:
+        detail = _parse_item_tax_rate(item.get("item_tax_rate"))
+        for account in configured_vat_accounts:
+            detail.pop(account, None)
+        detail[vat_account] = 0
+        item.item_tax_rate = json.dumps(detail)
+
+
+@frappe.whitelist()
+
+def get_purchase_invoice_requirements() -> dict:
+    """Return submit-time purchase requirements used by the form UI."""
+    settings = frappe.get_cached_doc("Nepal Compliance Settings")
+    return {
+        "bill_date": int(bool(settings.get("require_supplier_bill_date"))),
+        "attachment": int(bool(settings.get("require_purchase_invoice_attachment"))),
+    }
+
+def parse_item_vat_entry(value):
+    """Return (rate, amount) from stored or ERPNext item_wise_tax_detail values.
+
+    Accepts [rate, amount], a dict with tax_rate/tax_amount, or a bare amount
+    (legacy item_vat_detail JSON written before rates were stored).
+    """
+    if value is None:
+        return 0.0, 0.0
+    if isinstance(value, dict):
+        rate = value.get("tax_rate")
+        if rate is None:
+            rate = value.get("rate")
+        amount = value.get("tax_amount")
+        if amount is None:
+            amount = value.get("amount")
+        return flt(rate), flt(amount)
+    if isinstance(value, (list, tuple)):
+        rate = flt(value[0]) if len(value) > 0 else 0.0
+        amount = flt(value[1]) if len(value) > 1 else 0.0
+        return rate, amount
+    return 0.0, flt(value)
+
+def accumulate_item_vat(item_vat, item_key, rate, amount):
+    """Add a VAT row contribution, blending rates when the same item is taxed twice."""
+    prev_rate, prev_amount = parse_item_vat_entry(item_vat.get(item_key))
+    amount = flt(amount)
+    rate = flt(rate)
+    total_amount = prev_amount + amount
+    if prev_amount and prev_rate and rate and abs(prev_rate - rate) > 1e-9:
+        prev_base = prev_amount / (prev_rate / 100.0)
+        new_base = amount / (rate / 100.0)
+        total_base = prev_base + new_base
+        blended = (total_amount / total_base * 100.0) if total_base else rate
+        item_vat[item_key] = [blended, total_amount]
+    else:
+        item_vat[item_key] = [rate or prev_rate, total_amount]
+
+def add_item_wise_vat(item_vat, item_wise_tax_detail):
+    """Merge one tax row's item_wise_tax_detail into the per-item VAT map."""
+    detail = item_wise_tax_detail
+    if isinstance(detail, str):
+        try:
+            detail = json.loads(detail)
+        except (TypeError, ValueError):
+            detail = {}
+    for item_key, rate_amount in (detail or {}).items():
+        rate, amount = parse_item_vat_entry(rate_amount)
+        accumulate_item_vat(item_vat, item_key, rate, amount)
+
+def taxable_base_from_vat(vat_amount, rate, net_amount):
+    """Amount VAT was charged on (net + prior rows such as excise/duty).
+
+    Falls back to net_amount when rate is 0 (manually booked VAT, zero-rated).
+    """
+    if flt(rate):
+        # round() matches Frappe's default banker's rounding and does not
+        # depend on System Settings (flt(x, 2) can collapse to 0 without them).
+        return round(flt(vat_amount) / (flt(rate) / 100.0), 2)
+    return flt(net_amount)
+
+def item_taxable_amount(item, row_vat, item_vat_map):
+    """Taxable base for one item row: VAT ÷ rate, falling back to net amount."""
+    key = item.get("item_code") or item.get("item_name")
+    rate, _amount = parse_item_vat_entry(item_vat_map.get(key))
+    return taxable_base_from_vat(row_vat, rate, item.get("net_amount"))
+
+def tax_row_amount(tax):
+    """Tax amount after discount when set, else tax_amount."""
+    return flt(
+        tax.tax_amount_after_discount_amount
+        if tax.tax_amount_after_discount_amount is not None
+        else tax.tax_amount
+    )


### PR DESCRIPTION
### Proposed change
Add per-item VAT helpers, PAN bill VAT override, and purchase-invoice requirement flags.

**Base:** `staging`  
**Size vs `staging`:** +115 / −1 (116 lines).

Depends on #316 and the taxable VAT template helpers PR.

### Breaking change
- [x] ✅ No

### Type of change
- [x] ⚡️ Feature (`MINOR v0.x.0`)