### PR TITLE
chore: ignore local node_modules symlink and unique VAT company rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+# Local asset symlink (absolute path; do not track)
+nepal_compliance/public/node_modules

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_vat_account/nepal_compliance_vat_account.json
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_vat_account/nepal_compliance_vat_account.json
@@ -17,7 +17,8 @@
    "in_list_view": 1,
    "label": "Company",
    "options": "Company",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "sales_vat_account",


### PR DESCRIPTION
### Proposed change
Ignore the local `public/node_modules` symlink and mark VAT account Company as unique.

**Base:** `staging`  
**Size vs `staging`:** +5 / −2 (7 lines).

Does not delete the tracked staging symlink.

### Breaking change
- [x] ✅ No

### Type of change
- [x] 🧹 Chore (`PATCH v0.0.x`)