### PR TITLE
fix(ird): complete format_ird_month_label after the date/picker split

### DIFF
--- a/nepal_compliance/public/js/ird_bs_dates.js
+++ b/nepal_compliance/public/js/ird_bs_dates.js
@@ -278,3 +278,16 @@ nepal_compliance.format_ird_year_np = function (year) {
 };
 
 nepal_compliance.format_ird_month_label = function (value) {
+	if (!value) {
+		return "";
+	}
+	const parts = String(value).split("-").map(Number);
+	if (parts.length < 2 || !parts[0] || !parts[1]) {
+		return value;
+	}
+	const names =
+		(typeof NepaliDateLib !== "undefined" && NepaliDateLib.MONTH_NAMES_NE_BS) ||
+		nepal_compliance.IRD_BS_MONTHS_EN;
+	const np = names[parts[1] - 1] || value;
+	return `${np} ${nepal_compliance.format_ird_year_np(parts[0])}`;
+};

--- a/nepal_compliance/public/js/ird_month_picker.js
+++ b/nepal_compliance/public/js/ird_month_picker.js
@@ -3,20 +3,6 @@
 
 frappe.provide("nepal_compliance");
 
-	if (!value) {
-		return "";
-	}
-	const parts = String(value).split("-").map(Number);
-	if (parts.length < 2 || !parts[0] || !parts[1]) {
-		return value;
-	}
-	const names =
-		(typeof NepaliDateLib !== "undefined" && NepaliDateLib.MONTH_NAMES_NE_BS) ||
-		nepal_compliance.IRD_BS_MONTHS_EN;
-	const np = names[parts[1] - 1] || value;
-	return `${np} ${nepal_compliance.format_ird_year_np(parts[0])}`;
-};
-
 nepal_compliance.ird_month_entries = function () {
 	if (typeof NepaliDateLib !== "undefined" && NepaliDateLib.BS_MONTHS_WITH_AD) {
 		return NepaliDateLib.BS_MONTHS_WITH_AD;


### PR DESCRIPTION
### Proposed change
Complete `format_ird_month_label` in `ird_bs_dates.js` and remove the leftover function body from the top of `ird_month_picker.js`. The #324/#325 split cut that function in half, so both scripts currently fail to parse.

**Base:** `staging`  
**Size vs `staging`:** +13 / −14 (27 lines).

### Breaking change
- [x] ✅ No

### Type of change
- [x] 🐛 Bug Fix (`PATCH v0.0.x`)