### PR TITLE
fix(ird): restore bill total and VAT-exempt template wiring

### DIFF
--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -208,6 +208,7 @@ function show_preview_dialog(preview, values) {
 					<td class="text-right">${fmt(row.old_taxable_amount)} → ${fmt(row.new_taxable_amount)}</td>
 					<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
 					<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
+					<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
 				</tr>`;
 			})
 			.join("");
@@ -222,6 +223,7 @@ function show_preview_dialog(preview, values) {
 						<th>${__("Taxable")}</th>
 						<th>${__("Non-Taxable")}</th>
 						<th>${__("VAT")}</th>
+						<th>${__("Bill Total")}</th>
 					</tr>
 				</thead>
 				<tbody>${rows}</tbody>
@@ -230,8 +232,8 @@ function show_preview_dialog(preview, values) {
 	}
 
 	const html = `
-		<p>${__("Taxable amount will become the VAT base (VAT ÷ rate). Invoices where VAT is charged on a previous-row total (excise, import duty) will increase. Invoices where VAT is charged on net total stay the same.")}</p>
-		<p>${__("Fields that may change: Taxable Amount, Non-Taxable Amount, VAT Amount, and the hidden item VAT detail. IRD Sales/Purchase (and return) registers will use the new taxable column for these invoices. A comment with the new figures is added on each changed invoice.")}</p>
+		<p>${__("Taxable amount will become the VAT base (VAT ÷ rate). Invoices where VAT is charged on a previous-row total (excise, import duty) will increase. Invoices where VAT is charged on net total stay the same. Purchase invoices with TDS update Bill Total to Grand Total plus TDS (the billed value before withholding).")}</p>
+		<p>${__("Fields that may change: Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and the hidden item VAT detail. IRD Sales/Purchase (and return) registers will use the new taxable column and Bill Total for these invoices. A comment with the new figures is added on each changed invoice.")}</p>
 		<ul>
 			${fy_line}
 			<li>${__("Posting date range")}: <b>${frappe.utils.escape_html(preview.from_date)}</b> – <b>${frappe.utils.escape_html(preview.to_date)}</b></li>

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -45,7 +45,15 @@ def _count_invoices(from_date, to_date):
 
 def _iter_invoice_rows(from_date, to_date):
     """Yield (doctype, row) for submitted invoices, in batches of BATCH_SIZE."""
-    fields = ["name", "company", "posting_date", "taxable_amount", "non_taxable_amount", "vat_amount"]
+    fields = [
+        "name",
+        "company",
+        "posting_date",
+        "taxable_amount",
+        "non_taxable_amount",
+        "vat_amount",
+        "summary_grand_total",
+    ]
     for doctype in DOCTYPE_ORDER:
         start = 0
         while True:
@@ -72,11 +80,12 @@ def _amt(value):
 
 
 def _figures_changed(old, new):
-    """True when taxable, non-taxable, or VAT amounts would change."""
+    """True when taxable, non-taxable, VAT, or Bill Total would change."""
     return (
         _amt(old.taxable_amount) != _amt(new.taxable_amount)
         or _amt(old.non_taxable_amount) != _amt(new.non_taxable_amount)
         or _amt(old.vat_amount) != _amt(new.vat_amount)
+        or _amt(old.summary_grand_total) != _amt(new.summary_grand_total)
     )
 
 
@@ -101,6 +110,8 @@ def _compute_refresh_row(doctype, row):
         "new_non_taxable_amount": _amt(doc.non_taxable_amount),
         "old_vat_amount": _amt(row.vat_amount),
         "new_vat_amount": _amt(doc.vat_amount),
+        "old_summary_grand_total": _amt(row.summary_grand_total),
+        "new_summary_grand_total": _amt(doc.summary_grand_total),
         "summary_grand_total": doc.summary_grand_total,
         "item_vat_detail": doc.item_vat_detail,
     }
@@ -125,7 +136,7 @@ def _scan_changes(from_date, to_date):
             by_doctype[doctype] += 1
             if len(changes) < PREVIEW_TABLE_LIMIT:
                 changes.append(
-                    {k: change[k] for k in change if k not in ("summary_grand_total", "item_vat_detail")}
+                    {k: change[k] for k in change if k != "item_vat_detail"}
                 )
 
     changed = sum(by_doctype.values())
@@ -164,11 +175,12 @@ def _apply_change(change):
         "Comment",
         _(
             "Nepal Compliance: taxable summary recomputed from VAT base "
-            "(VAT ÷ rate). Taxable: {0}, Non-Taxable: {1}, VAT: {2}"
+            "(VAT ÷ rate). Taxable: {0}, Non-Taxable: {1}, VAT: {2}, Bill Total: {3}"
         ).format(
             flt(change["new_taxable_amount"], 2),
             flt(change["new_non_taxable_amount"], 2),
             flt(change["new_vat_amount"], 2),
+            flt(change["new_summary_grand_total"], 2),
         ),
     )
 

--- a/nepal_compliance/test/test_pan_bill.py
+++ b/nepal_compliance/test/test_pan_bill.py
@@ -52,6 +52,21 @@ class TestPanBill(unittest.TestCase):
         self.assertEqual(base, 1000)
         self.assertIsNone(reason)
 
+    @patch("nepal_compliance.utils.frappe.get_all", return_value=["VAT Exempt (Sales) - ACME"])
+    @patch("nepal_compliance.utils.frappe.get_doc")
+    def test_exempt_template_accepts_side(self, get_doc, get_all):
+        get_doc.return_value = frappe._dict(
+            taxes=[frappe._dict(tax_type="VAT Payable", tax_rate=0)]
+        )
+
+        name = utils.get_or_create_vat_exempt_template("ACME", "VAT Payable", "sales")
+
+        self.assertEqual(name, "VAT Exempt (Sales) - ACME")
+        self.assertEqual(
+            get_all.call_args.kwargs["filters"]["title"],
+            "VAT Exempt (Sales)",
+        )
+
     @patch("nepal_compliance.default_tax_template.frappe.get_doc")
     @patch("nepal_compliance.default_tax_template.frappe.db.exists")
     def test_company_nepal_tax_becomes_purchase_default(self, exists, get_doc):

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -249,12 +249,12 @@ def get_configured_vat_accounts():
             }
     return accounts
 
-VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
-
-def get_or_create_vat_exempt_template(company, vat_account):
+def get_or_create_vat_exempt_template(company, vat_account, side):
+    """Return the side-specific 0% VAT-exempt template, creating it if needed."""
+    title = vat_exempt_template_title(side)
     existing = frappe.get_all(
         "Item Tax Template",
-        filters={"company": company, "title": VAT_EXEMPT_TEMPLATE_TITLE},
+        filters={"company": company, "title": title},
         pluck="name",
     )
     if existing:
@@ -270,7 +270,7 @@ def get_or_create_vat_exempt_template(company, vat_account):
 
     template = frappe.get_doc({
         "doctype": "Item Tax Template",
-        "title": VAT_EXEMPT_TEMPLATE_TITLE,
+        "title": title,
         "company": company,
         "taxes": [{"tax_type": vat_account, "tax_rate": 0}],
     }).insert(ignore_permissions=True)
@@ -298,7 +298,7 @@ def apply_vat_exemption_for_nontaxable_items(doc, method):
     if not any(tax.account_head == vat_account for tax in doc.get("taxes") or []):
         return
 
-    template_name = get_or_create_vat_exempt_template(doc.company, vat_account)
+    template_name = get_or_create_vat_exempt_template(doc.company, vat_account, side)
     for item in flagged:
         item.item_tax_template = template_name
         item.item_tax_rate = json.dumps({vat_account: 0})
@@ -415,9 +415,9 @@ def set_taxable_amounts(doc, method):
     doc.taxable_amount = taxable_amount
     doc.non_taxable_amount = non_taxable_amount
     doc.vat_amount = vat_amount
-    doc.summary_grand_total = (
-        flt(doc.grand_total) if doc.get("disable_rounded_total") else (flt(doc.rounded_total) or flt(doc.grand_total))
-    )
+    # Bill Total is grand_total plus TDS: ERPNext deducts TDS from grand_total,
+    # IRD wants the billed value (net + VAT) before withholding.
+    set_bill_total(doc, vat_account)
 
 def get_vat_breakup(invoice_doctype, invoice_company_map):
     """
@@ -512,9 +512,10 @@ def distribute_item_vat(items, item_vat_map):
     return row_vat
 
 VAT_TAXABLE_TEMPLATE_TITLE = "Nepal Tax"
+
 def vat_exempt_template_title(side):
     """Return the stable side-specific title for a VAT-exempt template."""
-    return f"VAT Exempt ({'Sales' if side == 'sales' else 'Purchase'})"
+    return f"{VAT_EXEMPT_TEMPLATE_TITLE} ({'Sales' if side == 'sales' else 'Purchase'})"
 
 
 def format_vat_rate(rate):


### PR DESCRIPTION
## Summary
- Add TDS back into Bill Total (`summary_grand_total`) on invoice save, so IRD Bill Total is the billed value before withholding
- Recompute Taxable Summary now detects, previews, writes, and comments Bill Total (including invoices where only Bill Total is wrong)
- Restore `side` on `get_or_create_vat_exempt_template` so saving Nepal Compliance Settings with VAT accounts no longer 500s
- Create side-specific VAT Exempt (Sales/Purchase) templates

## Test plan
- [ ] Save Nepal Compliance Settings with Sales/Purchase VAT accounts for Yarsa Tech (no 500)
- [ ] Confirm VAT Exempt (Sales) and VAT Exempt (Purchase) templates exist for the company
- [ ] Save a Purchase Invoice with VAT and TDS; Bill Total should be Grand Total + TDS
- [ ] Run **Recompute Taxable Summary** for posting date 2026-08-11
- [ ] Confirm `YTPI-2083/84-00194` Bill Total updates from 257,328.67 to 260,790.49
- [ ] Confirm Purchase Register IRD Total for that invoice matches the new Bill Total