### PR TITLE
feat(vat): include previous-row duty and excise in the taxable VAT base

### DIFF
--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,0 +1,239 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from nepal_compliance import utils
+
+
+class TestTaxableSummaryCalculation(unittest.TestCase):
+    def make_invoice(self, taxable_vat=544.61):
+        return frappe._dict(
+            doctype="Purchase Invoice",
+            company="Yarsa Labs",
+            grand_total=32762.94,
+            items=[
+                frappe._dict(
+                    item_code="Taxable",
+                    net_amount=4189.33,
+                    is_nontaxable_item=0,
+                ),
+                frappe._dict(
+                    item_code="Non-Taxable",
+                    net_amount=28029,
+                    is_nontaxable_item=1,
+                ),
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Payable",
+                    tax_amount_after_discount_amount=taxable_vat,
+                    tax_amount=taxable_vat,
+                    item_wise_tax_detail=json.dumps(
+                        {"Taxable": [13, taxable_vat]}
+                    ),
+                    add_deduct_tax="Add",
+                    is_tax_withholding_account=0,
+                )
+            ],
+        )
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_csv_example_uses_non_taxable_item_flag(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice()
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 4189.33)
+        self.assertEqual(invoice.non_taxable_amount, 28029)
+        self.assertEqual(invoice.vat_amount, 544.61)
+        self.assertEqual(invoice.summary_grand_total, 32762.94)
+        self.assertEqual(check["expected_vat"], 544.61)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_mismatch_retains_recorded_vat(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=500)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.vat_amount, 500)
+        self.assertEqual(check["expected_vat"], 544.61)
+        self.assertEqual(check["vat_difference"], -44.61)
+        self.assertTrue(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_pan_bill_makes_every_item_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+        invoice.is_pan_or_abbreviated_bill = 1
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_purchase_invoice_without_tax_rows_is_fully_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+        invoice.taxes = []
+        invoice.grand_total = 32218.33
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(invoice.vat_amount, 0)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_purchase_invoice_with_zero_vat_is_fully_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(invoice.vat_amount, 0)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_sub_paisa_difference_is_within_rounding_tolerance(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=544.614)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_vat_on_previous_row_is_detected(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                ),
+            ],
+        )
+
+        self.assertTrue(utils.vat_charged_on_added_taxes(invoice))
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_on_net_total_vat_is_not_added_taxes(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Net Total",
+                ),
+            ],
+        )
+
+        self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_previous_row_vat_includes_excise_in_taxable_base(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=5753.9318,
+            items=[
+                frappe._dict(
+                    item_code="Y101642",
+                    net_amount=4849.5,
+                    is_nontaxable_item=0,
+                )
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                    tax_amount=0,
+                    tax_amount_after_discount_amount=0,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [0.0, 0.0]},
+                ),
+                frappe._dict(
+                    account_head="Excise",
+                    charge_type="On Previous Row Total",
+                    tax_amount=242.475,
+                    tax_amount_after_discount_amount=242.475,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [5.0, 242.475]},
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                    tax_amount=661.9568,
+                    tax_amount_after_discount_amount=661.9568,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [13.0, 661.95675]},
+                ),
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 5091.98)
+        self.assertEqual(invoice.non_taxable_amount, 0)
+        self.assertEqual(check["expected_vat"], 661.96)
+        self.assertEqual(check["recorded_vat"], 661.96)
+        self.assertFalse(check["has_vat_mismatch"])
+        self.assertTrue(check["vat_on_added_taxes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -236,6 +236,28 @@ def tax_row_amount(tax):
         else tax.tax_amount
     )
 
+PREVIOUS_ROW_VAT_CHARGE_TYPES = ("On Previous Row Total", "On Previous Row Amount")
+
+
+def vat_charged_on_added_taxes(doc, vat_account=None):
+    """True when VAT is calculated on a previous tax row (duty, excise, etc.).
+
+    Item-net × 13% is not the VAT base in that stack, so Taxable Summary
+    Refresh must not rewrite these invoices from the itemwise check.
+    """
+    if doc.doctype not in ("Sales Invoice", "Purchase Invoice"):
+        return False
+    if not vat_account:
+        side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+        vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+    if not vat_account:
+        return False
+    return any(
+        tax.account_head == vat_account
+        and tax.charge_type in PREVIOUS_ROW_VAT_CHARGE_TYPES
+        for tax in (doc.get("taxes") or [])
+    )
+
 VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
 
 def get_configured_vat_accounts():
@@ -379,7 +401,13 @@ def validate_duplicate_bill_no(doc, method):
                 )
             )
 
-def set_taxable_amounts(doc, method):
+def set_taxable_amounts(doc, method, consider_is_non_taxable_item=False):
+    """Set IRD taxable summary fields and return an optional VAT calculation check.
+
+    The normal document-event path keeps the historical item-wise VAT
+    classification. The settings recompute can instead classify items solely
+    from the item's Is Non-Taxable Item flag.
+    """
     side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
     vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
 
@@ -389,26 +417,39 @@ def set_taxable_amounts(doc, method):
         for tax in doc.get("taxes") or []:
             if tax.account_head != vat_account:
                 continue
-            vat_amount += flt(
-                tax.tax_amount_after_discount_amount
-                if tax.tax_amount_after_discount_amount is not None
-                else tax.tax_amount
-            )
-            detail = tax.item_wise_tax_detail
-            if isinstance(detail, str):
-                try:
-                    detail = json.loads(detail)
-                except (TypeError, ValueError):
-                    detail = {}
-            for item_key, rate_amount in (detail or {}).items():
-                if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
-                    item_vat[item_key] = item_vat.get(item_key, 0.0) + flt(rate_amount[1])
+            vat_amount += tax_row_amount(tax)
+            add_item_wise_vat(item_vat, tax.item_wise_tax_detail)
+
+    items = list(doc.get("items") or [])
+    row_vat = distribute_item_vat(items, item_vat)
+    include_added_taxes = vat_charged_on_added_taxes(doc, vat_account)
 
     taxable_amount = non_taxable_amount = 0.0
-    for item in doc.get("items") or []:
+    force_all_non_taxable = bool(
+        doc.get("is_pan_or_abbreviated_bill")
+        or (
+            doc.doctype == "Purchase Invoice"
+            and (not doc.get("taxes") or not flt(vat_amount))
+        )
+    )
+    for item, item_row_vat in zip(items, row_vat, strict=True):
         amt = flt(item.get("net_amount"))
-        if item.get("is_nontaxable_item") or not flt(item_vat.get(item.get("item_code") or item.get("item_name"))):
+        if consider_is_non_taxable_item:
+            is_non_taxable = bool(
+                force_all_non_taxable or item.get("is_nontaxable_item")
+            )
+        else:
+            item_key = item.get("item_code") or item.get("item_name")
+            is_non_taxable = bool(
+                item.get("is_nontaxable_item")
+                or not flt(parse_item_vat_entry(item_vat.get(item_key))[1])
+            )
+        if is_non_taxable:
             non_taxable_amount += amt
+        elif include_added_taxes:
+            # VAT was charged on net + prior rows (duty/excise). Use VAT ÷ rate
+            # so expected VAT is 13% of that same base.
+            taxable_amount += item_taxable_amount(item, item_row_vat, item_vat)
         else:
             taxable_amount += amt
 
@@ -418,6 +459,20 @@ def set_taxable_amounts(doc, method):
     # Bill Total is grand_total plus TDS: ERPNext deducts TDS from grand_total,
     # IRD wants the billed value (net + VAT) before withholding.
     set_bill_total(doc, vat_account)
+
+    if not consider_is_non_taxable_item:
+        return None
+
+    expected_vat = flt(taxable_amount * 0.13, 2)
+    recorded_vat = flt(vat_amount, 2)
+    difference = flt(recorded_vat - expected_vat, 2)
+    return {
+        "expected_vat": expected_vat,
+        "recorded_vat": recorded_vat,
+        "vat_difference": difference,
+        "has_vat_mismatch": abs(difference) >= 0.01,
+        "vat_on_added_taxes": include_added_taxes,
+    }
 
 def get_vat_breakup(invoice_doctype, invoice_company_map):
     """


### PR DESCRIPTION
## Recompute Taxable Summary (IRD Report Related Changes)
- When VAT is charged on a previous tax row (import duty, excise, or similar), Taxable Amount is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%.
- Document-save still uses the existing item-wise VAT split. The settings recompute can classify from the Is Non-Taxable Item flag, including PAN/Abbreviated Bill and zero-VAT purchases.
- Recorded tax-table VAT is retained. This PR does not change Desk UI.

Split from #351 (1/4).

## Test plan
- [ ] Purchase invoice with Import Duty → Excise → VAT On Previous Row Total: taxable is VAT base, not item net (e.g. 4,849.50 → 5,091.98).
- [ ] On Net Total VAT invoices are unchanged.
- [ ] Saving a normal Sales/Purchase Invoice still writes taxable summary as before.