### PR TITLE
feat(ird): add selectable taxable-summary refresh, CSV download, and POST-only RPCs

### DIFF
--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -21,6 +21,15 @@ function open_date_prompt() {
 		title: __("Recompute Taxable Summary"),
 		fields: [
 			{
+				fieldname: "recompute_help_button",
+				fieldtype: "HTML",
+				options: `<div class="text-right">
+					<button type="button" class="btn btn-xs btn-default recompute-help" title="${__(
+						"About Recompute Taxable Summary"
+					)}">?</button>
+				</div>`,
+			},
+			{
 				fieldname: "fiscal_year",
 				fieldtype: "Link",
 				options: "Fiscal Year",
@@ -56,11 +65,20 @@ function open_date_prompt() {
 				reqd: 1,
 			},
 			{
+				fieldname: "consider_is_non_taxable_item",
+				fieldtype: "Check",
+				label: __("Consider Is Non-Taxable Item"),
+				default: 0,
+				description: __(
+					"Classify flagged item rows as non-taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT."
+				),
+			},
+			{
 				fieldname: "help",
 				fieldtype: "HTML",
 				options: `<p class="text-muted">
 					${__(
-						"Select a Fiscal Year to fill the dates, or enter a posting date range. Only submitted Sales and Purchase Invoices in this range will be scanned."
+						"Only submitted Sales and Purchase Invoices in this range will be scanned. VAT calculation mismatches are warnings; VAT recorded in invoice tax rows is retained."
 					)}
 				</p>`,
 			},
@@ -76,6 +94,34 @@ function open_date_prompt() {
 		},
 	});
 	dialog.show();
+	dialog.fields_dict.recompute_help_button.$wrapper
+		.find(".recompute-help")
+		.on("click", show_taxable_summary_help);
+}
+
+function show_taxable_summary_help() {
+	frappe.msgprint({
+		title: __("About Recompute Taxable Summary"),
+		message: `
+			<p>${__(
+				"Use this tool to preview and correct the Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and item VAT summary stored on submitted Sales and Purchase Invoices. You can select which suggestions to apply."
+			)}</p>
+			<p><b>${__("Example")}</b></p>
+			<ul>
+				<li>${__("Taxable item total")}: ${fmt(4189.33)}</li>
+				<li>${__("Non-taxable item total")}: ${fmt(28029)}</li>
+				<li>${__("Expected VAT")}: ${fmt(4189.33)} × 13% = ${fmt(544.61)}</li>
+				<li>${__("Bill Total")}: ${fmt(32218.33)} + ${fmt(544.61)} = ${fmt(32762.94)}</li>
+			</ul>
+			<p>${__(
+				"If Is PAN/Abbreviated Bill is checked, a Purchase Invoice has no Taxes and Charges rows, or its recorded VAT is zero, all its items are treated as non-taxable and expected VAT is zero."
+			)}</p>
+			<p>${__(
+				"If VAT is charged on a previous tax row (import duty, excise, or similar), taxable value is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%."
+			)}</p>
+		`,
+		indicator: "blue",
+	});
 }
 
 function listen_for_preview_done() {
@@ -124,6 +170,7 @@ function run_preview(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,
@@ -180,91 +227,247 @@ function show_preview_dialog(preview, values) {
 	const fy_line = values.fiscal_year
 		? `<li>${__("Fiscal Year")}: <b>${frappe.utils.escape_html(values.fiscal_year)}</b></li>`
 		: "";
-	const more_line = preview.hidden_rows
-		? `<p class="text-muted">${__("…and {0} more invoice(s) not shown in the table. Confirm still updates all of them.", [preview.hidden_rows])}</p>`
-		: "";
 	const batch_line = preview.batched
-		? `<p><b>${__("More than 500 invoices are in this range. Confirm will run in the background in batches of 500.")}</b></p>`
+		? `<p><b>${__("More than 500 invoices were scanned. Large selections will be applied in the background.")}</b></p>`
 		: "";
-
-	let table = "";
-	if (preview.changes && preview.changes.length) {
-		const rows = preview.changes
-			.map((row) => {
-				const name = frappe.utils.escape_html(row.name);
-				const company = frappe.utils.escape_html(row.company || "");
-				const doctype = frappe.utils.escape_html(row.doctype);
-				const invoice_link = frappe.utils.get_form_link(
-					row.doctype,
-					row.name,
-					true,
-					name
-				);
-				return `<tr>
-					<td>${doctype}</td>
-					<td>${invoice_link}</td>
-					<td>${frappe.utils.escape_html(row.posting_date || "")}</td>
-					<td>${company}</td>
-					<td class="text-right">${fmt(row.old_taxable_amount)} → ${fmt(row.new_taxable_amount)}</td>
-					<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
-					<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
-					<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
-				</tr>`;
-			})
-			.join("");
-		table = `<div class="mt-3" style="max-height: 320px; overflow: auto;">
-			<table class="table table-bordered table-sm">
-				<thead>
-					<tr>
-						<th>${__("Type")}</th>
-						<th>${__("Invoice")}</th>
-						<th>${__("Posting Date")}</th>
-						<th>${__("Company")}</th>
-						<th>${__("Taxable")}</th>
-						<th>${__("Non-Taxable")}</th>
-						<th>${__("VAT")}</th>
-						<th>${__("Bill Total")}</th>
-					</tr>
-				</thead>
-				<tbody>${rows}</tbody>
-			</table>
-		</div>${more_line}`;
-	}
+	const suggestions = preview.changes || [];
+	const can_select = (row) => row.would_change;
+	const selectable_count = suggestions.filter(can_select).length;
+	const selected = new Set(
+		suggestions
+			.map((row, index) => (can_select(row) ? index : null))
+			.filter((index) => index !== null)
+	);
+	const page_size = 50;
+	let page = 0;
 
 	const html = `
-		<p>${__("Taxable amount will become the VAT base (VAT ÷ rate). Invoices where VAT is charged on a previous-row total (excise, import duty) will increase. Invoices where VAT is charged on net total stay the same. Purchase invoices with TDS update Bill Total to Grand Total plus TDS (the billed value before withholding).")}</p>
-		<p>${__("Fields that may change: Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and the hidden item VAT detail. IRD Sales/Purchase (and return) registers will use the new taxable column and Bill Total for these invoices. A comment with the new figures is added on each changed invoice.")}</p>
+		<p>${__("When the item flag option is enabled, flagged item totals are Non-Taxable and the remaining item totals are Taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT. Expected VAT is Taxable × 13%, including duty or excise when VAT is charged on a previous tax row. A mismatch is reported, but recorded VAT is retained.")}</p>
+		<p>${__("Applying updates only the selected taxable-summary suggestions. The audit comment records old and new Taxable, Non-Taxable, VAT, and Bill Total values.")}</p>
 		<ul>
 			${fy_line}
 			<li>${__("Posting date range")}: <b>${frappe.utils.escape_html(preview.from_date)}</b> – <b>${frappe.utils.escape_html(preview.to_date)}</b></li>
+			<li>${__("Consider Is Non-Taxable Item")}: <b>${preview.consider_is_non_taxable_item ? __("Yes") : __("No")}</b></li>
 			<li>${__("Scanned")}: <b>${preview.scanned}</b></li>
 			<li>${__("Would change")}: <b>${preview.changed}</b> (${__("Sales")}: ${preview.sales_changed}, ${__("Purchase")}: ${preview.purchase_changed})</li>
+			<li>${__("Calculation warnings")}: <b>${preview.calculation_warnings || 0}</b></li>
 			<li>${__("Unchanged")}: <b>${preview.unchanged}</b></li>
 			<li>${__("Skipped (no VAT account configured)")}: <b>${preview.skipped}</b></li>
 			<li>${__("Denied by permissions")}: <b>${preview.denied || 0}</b></li>
 			<li>${__("Failed")}: <b>${preview.failed || 0}</b></li>
 		</ul>
 		${batch_line}
-		${table}
+		<div class="taxable-summary-selection ${suggestions.length ? "" : "hide"}">
+			<div class="d-flex align-items-center mb-2" style="gap: 8px; flex-wrap: wrap;">
+				<button type="button" class="btn btn-xs btn-default select-all">${__("Select All")}</button>
+				<button type="button" class="btn btn-xs btn-default unselect-all">${__("Unselect All")}</button>
+				<select class="form-control input-xs document-type-filter" style="width: auto;">
+					<option value="Sales Invoice">${__("Sales Invoice")}</option>
+					<option value="Sales Return">${__("Sales Return")}</option>
+					<option value="Purchase Invoice">${__("Purchase Invoice")}</option>
+					<option value="Purchase Return">${__("Purchase Return")}</option>
+				</select>
+				<button type="button" class="btn btn-xs btn-default select-type">${__("Select Type")}</button>
+				<button type="button" class="btn btn-xs btn-default unselect-type">${__("Unselect Type")}</button>
+				<button type="button" class="btn btn-xs btn-default download-csv">${__("Download CSV")}</button>
+				<span class="selected-count text-muted"></span>
+				<span class="pagination-controls ml-auto">
+					<button type="button" class="btn btn-xs btn-default previous-page">${__("Previous")}</button>
+					<span class="page-count mx-2"></span>
+					<button type="button" class="btn btn-xs btn-default next-page">${__("Next")}</button>
+				</span>
+			</div>
+			<div style="max-height: 420px; overflow: auto;">
+				<table class="table table-bordered table-sm">
+					<thead>
+						<tr>
+							<th style="width: 32px;"></th>
+							<th>${__("Type")}</th>
+							<th>${__("Invoice")}</th>
+							<th>${__("Posting Date")}</th>
+							<th>${__("Company")}</th>
+							<th>${__("Taxable")}</th>
+							<th>${__("Non-Taxable")}</th>
+							<th>${__("VAT")}</th>
+							<th>${__("Bill Total")}</th>
+							<th>${__("Calculation Check")}</th>
+						</tr>
+					</thead>
+					<tbody class="suggestion-rows"></tbody>
+				</table>
+			</div>
+		</div>
 	`;
 
 	const dialog = new frappe.ui.Dialog({
 		title: __("Confirm Taxable Summary Refresh"),
 		size: "extra-large",
 		fields: [{ fieldname: "preview_html", fieldtype: "HTML" }],
-		primary_action_label: preview.changed ? __("Apply Changes") : __("Close"),
+		primary_action_label: selectable_count ? __("Apply Changes") : __("Close"),
 		primary_action() {
-			dialog.hide();
-			if (preview.changed) {
-				run_apply(values);
+			if (!selectable_count) {
+				dialog.hide();
+				return;
 			}
+			const selected_invoices = [...selected]
+				.filter((index) => can_select(suggestions[index]))
+				.map((index) => ({
+					doctype: suggestions[index].doctype,
+					name: suggestions[index].name,
+				}));
+			if (!selected_invoices.length) {
+				frappe.msgprint(__("Select at least one suggestion to apply."));
+				return;
+			}
+			dialog.hide();
+			run_apply(values, selected_invoices);
 		},
 	});
 	dialog.show();
-	dialog.fields_dict.preview_html.$wrapper.html(html);
-	if (!preview.changed) {
+	const $wrapper = dialog.fields_dict.preview_html.$wrapper;
+	$wrapper.html(html);
+
+	const render_row = (row, extra_check) => {
+		const name = frappe.utils.escape_html(row.name);
+		const invoice_link = frappe.utils.get_form_link(
+			row.doctype,
+			row.name,
+			true,
+			name
+		);
+		const check = row.calculation_check || {};
+		const calculation = check.has_vat_mismatch
+			? `<span class="text-danger">${__(
+					"Expected {0}; recorded {1}; difference {2}",
+					[
+						fmt(check.expected_vat),
+						fmt(check.recorded_vat),
+						fmt(check.vat_difference),
+					]
+				)}</span>`
+			: `<span class="text-success">${__("OK")}</span>`;
+		return `${extra_check}
+			<td>${frappe.utils.escape_html(row.document_type || row.doctype)}</td>
+			<td>${invoice_link}</td>
+			<td>${frappe.utils.escape_html(row.posting_date || "")}</td>
+			<td>${frappe.utils.escape_html(row.company || "")}</td>
+			<td class="text-right">${fmt(row.old_taxable_amount)} → ${fmt(row.new_taxable_amount)}</td>
+			<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
+			<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
+			<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
+			<td>${calculation}${row.would_change ? "" : `<br><small>${__("Review only; no summary change")}</small>`}</td>`;
+	};
+
+	const render_page = () => {
+		const page_count = Math.max(Math.ceil(suggestions.length / page_size), 1);
+		page = Math.min(Math.max(page, 0), page_count - 1);
+		const start = page * page_size;
+		const rows = suggestions.slice(start, start + page_size).map((row, offset) => {
+			const index = start + offset;
+			const disabled = can_select(row) ? "" : "disabled";
+			const checked = selected.has(index) ? "checked" : "";
+			return `<tr>${render_row(
+				row,
+				`<td><input type="checkbox" class="suggestion-select" data-index="${index}" ${checked} ${disabled}></td>`
+			)}</tr>`;
+		});
+		$wrapper.find(".suggestion-rows").html(rows.join(""));
+		$wrapper.find(".selected-count").text(
+			__("{0} of {1} suggestion(s) selected", [selected.size, selectable_count])
+		);
+		$wrapper.find(".download-csv").prop("disabled", !selected.size);
+		$wrapper.find(".page-count").text(
+			__("Page {0} of {1}", [page + 1, page_count])
+		);
+		$wrapper.find(".previous-page").prop("disabled", page === 0);
+		$wrapper.find(".next-page").prop("disabled", page >= page_count - 1);
+		dialog.get_primary_btn().prop("disabled", selectable_count && !selected.size);
+	};
+
+	$wrapper.on("change", ".suggestion-select", function () {
+		const index = Number(this.dataset.index);
+		if (this.checked) {
+			selected.add(index);
+		} else {
+			selected.delete(index);
+		}
+		render_page();
+	});
+	$wrapper.on("click", ".select-all", () => {
+		suggestions.forEach((row, index) => {
+			if (can_select(row)) selected.add(index);
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".unselect-all", () => {
+		selected.clear();
+		render_page();
+	});
+	$wrapper.on("click", ".select-type", () => {
+		const document_type = $wrapper.find(".document-type-filter").val();
+		suggestions.forEach((row, index) => {
+			if (can_select(row) && row.document_type === document_type) {
+				selected.add(index);
+			}
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".unselect-type", () => {
+		const document_type = $wrapper.find(".document-type-filter").val();
+		suggestions.forEach((row, index) => {
+			if (row.document_type === document_type) {
+				selected.delete(index);
+			}
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".download-csv", () => {
+		const selected_rows = [...selected]
+			.sort((a, b) => a - b)
+			.map((index) => suggestions[index])
+			.filter(Boolean);
+		if (!selected_rows.length) {
+			frappe.msgprint(__("Select at least one row to download."));
+			return;
+		}
+		frappe.call({
+			method: "nepal_compliance.taxable_summary.download_taxable_summary_csv",
+			args: {
+				rows: JSON.stringify(selected_rows),
+				from_date: preview.from_date,
+				to_date: preview.to_date,
+			},
+			freeze: true,
+			freeze_message: __("Preparing CSV..."),
+			callback(r) {
+				if (!r.message || !r.message.csv) {
+					return;
+				}
+				const blob = new Blob(["\uFEFF" + r.message.csv], {
+					type: "text/csv;charset=utf-8;",
+				});
+				const link = document.createElement("a");
+				link.href = URL.createObjectURL(blob);
+				link.download = r.message.filename || "taxable_summary.csv";
+				document.body.appendChild(link);
+				link.click();
+				link.remove();
+				URL.revokeObjectURL(link.href);
+			},
+		});
+	});
+	$wrapper.on("click", ".previous-page", () => {
+		page -= 1;
+		render_page();
+	});
+	$wrapper.on("click", ".next-page", () => {
+		page += 1;
+		render_page();
+	});
+	render_page();
+	if (!selectable_count) {
 		dialog.$wrapper.find(".modal-body").prepend(
-			`<div class="alert alert-info">${__("No invoices in this range would change.")}</div>`
+			`<div class="alert alert-info">${__("No invoices in this range would change. Review any calculation warnings below.")}</div>`
 		);
 	}
 }
@@ -294,15 +497,19 @@ function listen_for_refresh_done() {
 		}
 		frappe.msgprint({
 			title: __("Taxable Summary Refresh"),
-			indicator: data.denied || data.failed ? "orange" : "green",
+			indicator:
+				data.denied || data.failed || data.stale || data.calculation_warnings
+					? "orange"
+					: "green",
 			message: __(
-				"Updated {0} invoice(s) from {1} to {2}. Denied: {3}; skipped: {4}; failed: {5}.",
+				"Updated {0} invoice(s) from {1} to {2}. Warnings: {3}; denied: {4}; stale: {5}; failed: {6}.",
 				[
 				data.updated,
 				data.from_date,
 				data.to_date,
+				data.calculation_warnings || 0,
 				data.denied || 0,
-				data.skipped || 0,
+				data.stale || 0,
 				data.failed || 0,
 				]
 			),
@@ -310,7 +517,7 @@ function listen_for_refresh_done() {
 	});
 }
 
-function run_apply(values) {
+function run_apply(values, selected_invoices) {
 	frappe._taxable_summary_apply_pending = frappe._taxable_summary_apply_pending || {};
 	const already_running = Object.values(frappe._taxable_summary_apply_pending).some(
 		(pending) =>
@@ -328,6 +535,8 @@ function run_apply(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			selected_invoices: JSON.stringify(selected_invoices),
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,
@@ -350,17 +559,18 @@ function run_apply(values) {
 				}
 				frappe.msgprint(
 					__(
-						"More than 500 invoices are in this range. The update is running in the background in batches of 500. You will be notified when it finishes."
+						"More than 500 invoices were selected. The update is running in the background in batches of 500. You will be notified when it finishes."
 					)
 				);
 				return;
 			}
 			delete frappe._taxable_summary_apply_pending[request_id];
 			frappe.msgprint(
-				__("Updated {0} invoice(s). Denied: {1}; skipped: {2}; failed: {3}.", [
+				__("Updated {0} invoice(s). Warnings: {1}; denied: {2}; stale: {3}; failed: {4}.", [
 					r.message.updated,
+					r.message.calculation_warnings || 0,
 					r.message.denied || 0,
-					r.message.skipped || 0,
+					r.message.stale || 0,
 					r.message.failed || 0,
 				])
 			);
@@ -376,6 +586,15 @@ function open_tds_base_prompt() {
 	const dialog = new frappe.ui.Dialog({
 		title: __("Audit TDS Bases"),
 		fields: [
+			{
+				fieldname: "tds_help_button",
+				fieldtype: "HTML",
+				options: `<div class="text-right">
+					<button type="button" class="btn btn-xs btn-default tds-base-help" title="${__(
+						"About Audit TDS Bases"
+					)}">?</button>
+				</div>`,
+			},
 			{
 				fieldname: "fiscal_year",
 				fieldtype: "Link",
@@ -422,6 +641,29 @@ function open_tds_base_prompt() {
 		},
 	});
 	dialog.show();
+	dialog.fields_dict.tds_help_button.$wrapper
+		.find(".tds-base-help")
+		.on("click", show_tds_base_help);
+}
+
+function show_tds_base_help() {
+	frappe.msgprint({
+		title: __("About Audit TDS Bases"),
+		message: `
+			<p>${__(
+				"Use this tool to check the transaction-currency and company-currency TDS base fields on submitted Purchase Invoices where TDS is enabled and the withholding category calculates TDS on the taxable amount."
+			)}</p>
+			<p><b>${__("Example")}</b></p>
+			<p>${__(
+				"An invoice has a taxable value of {0} and VAT of {1}. If its stored TDS base is incorrectly {2}, the audit suggests changing the TDS base to {0}.",
+				[fmt(1000), fmt(130), fmt(1130)]
+			)}</p>
+			<p>${__(
+				"Applying updates only the two TDS base fields and adds an audit comment. It does not recalculate historical TDS, change VAT rows, or alter General Ledger entries."
+			)}</p>
+		`,
+		indicator: "blue",
+	});
 }
 
 function preview_tds_bases(values) {

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -1,13 +1,33 @@
 import frappe
 from frappe import _
-from frappe.utils import flt, getdate
+from frappe.utils import cint, flt, getdate
 from frappe.utils.background_jobs import enqueue
 
 from nepal_compliance.utils import set_taxable_amounts
+from frappe.utils.csvutils import to_csv
 
 BATCH_SIZE = 500
-PREVIEW_TABLE_LIMIT = 100
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
+TAXABLE_SUMMARY_CSV_COLUMNS = [
+    "Type",
+    "Invoice",
+    "Posting Date",
+    "Company",
+    "Taxable (Old)",
+    "Taxable (New)",
+    "Non-Taxable (Old)",
+    "Non-Taxable (New)",
+    "VAT (Old)",
+    "VAT (New)",
+    "Bill Total (Old)",
+    "Bill Total (New)",
+    "Would Change",
+    "Group",
+    "Expected VAT",
+    "Recorded VAT",
+    "Difference",
+    "Calculation Check",
+]
 
 
 def _ensure_permission():
@@ -49,6 +69,7 @@ def _iter_invoice_rows(from_date, to_date):
         "name",
         "company",
         "posting_date",
+        "is_return",
         "taxable_amount",
         "non_taxable_amount",
         "vat_amount",
@@ -74,6 +95,14 @@ def _iter_invoice_rows(from_date, to_date):
             start += BATCH_SIZE
 
 
+SUMMARY_COMPARE_FIELDS = (
+    "taxable_amount",
+    "non_taxable_amount",
+    "vat_amount",
+    "summary_grand_total",
+)
+
+
 def _amt(value):
     """Round a money field to 2 decimals, preserving None."""
     return None if value is None else flt(value, 2)
@@ -81,29 +110,49 @@ def _amt(value):
 
 def _figures_changed(old, new):
     """True when taxable, non-taxable, VAT, or Bill Total would change."""
-    return (
-        _amt(old.taxable_amount) != _amt(new.taxable_amount)
-        or _amt(old.non_taxable_amount) != _amt(new.non_taxable_amount)
-        or _amt(old.vat_amount) != _amt(new.vat_amount)
-        or _amt(old.summary_grand_total) != _amt(new.summary_grand_total)
+    return any(
+        _amt(old.get(field)) != _amt(new.get(field))
+        for field in SUMMARY_COMPARE_FIELDS
     )
 
 
-def _compute_refresh_row(doctype, row):
+def _document_type(doctype, is_return):
+    if not is_return:
+        return doctype
+    return "Sales Return" if doctype == "Sales Invoice" else "Purchase Return"
+
+
+def _compute_refresh_row(doctype, row, consider_is_non_taxable_item=False):
     """Recompute one invoice's taxable summary and classify the result."""
     doc = frappe.get_doc(doctype, row.name)
-    set_taxable_amounts(doc, None)
+    if not frappe.has_permission(doctype, "write", doc=doc):
+        return "denied", None
+
+    calculation_check = set_taxable_amounts(
+        doc,
+        None,
+        consider_is_non_taxable_item=consider_is_non_taxable_item,
+    )
     if doc.get("taxable_amount") is None:
         return "skipped", None
 
-    if not _figures_changed(row, doc):
+    figures_changed = _figures_changed(row, doc)
+    has_warning = bool(
+        calculation_check and calculation_check.get("has_vat_mismatch")
+    )
+    if not figures_changed and not has_warning:
         return "unchanged", None
 
-    return "changed", {
+    return ("changed" if figures_changed else "warning"), {
         "doctype": doctype,
+        "document_type": _document_type(doctype, row.get("is_return")),
         "name": row.name,
         "company": row.company,
         "posting_date": str(row.posting_date),
+        "would_change": figures_changed,
+        "vat_on_added_taxes": bool(
+            calculation_check and calculation_check.get("vat_on_added_taxes")
+        ),
         "old_taxable_amount": _amt(row.taxable_amount),
         "new_taxable_amount": _amt(doc.taxable_amount),
         "old_non_taxable_amount": _amt(row.non_taxable_amount),
@@ -113,31 +162,48 @@ def _compute_refresh_row(doctype, row):
         "old_summary_grand_total": _amt(row.summary_grand_total),
         "new_summary_grand_total": _amt(doc.summary_grand_total),
         "summary_grand_total": doc.summary_grand_total,
-        "item_vat_detail": doc.item_vat_detail,
+        "item_vat_detail": doc.get("item_vat_detail"),
+        "calculation_check": calculation_check,
     }
 
 
-def _scan_changes(from_date, to_date):
+def _scan_changes(from_date, to_date, consider_is_non_taxable_item=False):
     """Scan invoices in range and return preview rows plus counts."""
     scanned = 0
     unchanged = 0
     skipped = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
     by_doctype = {doctype: 0 for doctype in DOCTYPE_ORDER}
     changes = []
 
     for doctype, row in _iter_invoice_rows(from_date, to_date):
         scanned += 1
-        status, change = _compute_refresh_row(doctype, row)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Preview Failed for {0}").format(row.name)
+            )
+            continue
         if status == "skipped":
             skipped += 1
+        elif status == "denied":
+            denied += 1
         elif status == "unchanged":
             unchanged += 1
         else:
-            by_doctype[doctype] += 1
-            if len(changes) < PREVIEW_TABLE_LIMIT:
-                changes.append(
-                    {k: change[k] for k in change if k != "item_vat_detail"}
-                )
+            if change["calculation_check"] and change["calculation_check"].get(
+                "has_vat_mismatch"
+            ):
+                calculation_warnings += 1
+            if status == "changed":
+                by_doctype[doctype] += 1
+            changes.append({k: change[k] for k in change if k != "item_vat_detail"})
 
     changed = sum(by_doctype.values())
     return {
@@ -148,11 +214,14 @@ def _scan_changes(from_date, to_date):
         "changed": changed,
         "unchanged": unchanged,
         "skipped": skipped,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
         "sales_changed": by_doctype["Sales Invoice"],
         "purchase_changed": by_doctype["Purchase Invoice"],
         "batched": scanned > BATCH_SIZE,
         "changes": changes,
-        "hidden_rows": max(changed - len(changes), 0),
+        "consider_is_non_taxable_item": bool(consider_is_non_taxable_item),
     }
 
 
@@ -174,25 +243,87 @@ def _apply_change(change):
     doc.add_comment(
         "Comment",
         _(
-            "Nepal Compliance: taxable summary recomputed from VAT base "
-            "(VAT ÷ rate). Taxable: {0}, Non-Taxable: {1}, VAT: {2}, Bill Total: {3}"
+            "Nepal Compliance: taxable summary recomputed. "
+            "Taxable: {0} → {1}, Non-Taxable: {2} → {3}, "
+            "VAT: {4} → {5}, Bill Total: {6} → {7}."
         ).format(
+            flt(change["old_taxable_amount"], 2),
             flt(change["new_taxable_amount"], 2),
+            flt(change["old_non_taxable_amount"], 2),
             flt(change["new_non_taxable_amount"], 2),
+            flt(change["old_vat_amount"], 2),
             flt(change["new_vat_amount"], 2),
+            flt(change["old_summary_grand_total"], 2),
             flt(change["new_summary_grand_total"], 2),
         ),
     )
 
 
-def _run_apply(from_date, to_date):
-    """Apply recomputed taxable summary values, committing every BATCH_SIZE invoices."""
+def _parse_selected_invoices(selected_invoices):
+    """Return validated selected invoice keys from a JSON/list payload."""
+    selected = (
+        frappe.parse_json(selected_invoices)
+        if isinstance(selected_invoices, str)
+        else selected_invoices
+    )
+    if not isinstance(selected, list):
+        frappe.throw(_("Selected invoices must be a list."))
+
+    keys = set()
+    for row in selected:
+        if not isinstance(row, dict):
+            frappe.throw(_("Each selected invoice must include a type and name."))
+        doctype = row.get("doctype")
+        name = row.get("name")
+        if doctype not in DOCTYPE_ORDER or not name:
+            frappe.throw(_("Invalid selected invoice: {0} {1}").format(doctype, name))
+        keys.add((doctype, name))
+    return keys
+
+
+def _run_apply(
+    from_date,
+    to_date,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+):
+    """Apply selected recomputed values, committing every BATCH_SIZE invoices."""
+    selected = (
+        set(selected_invoices)
+        if isinstance(selected_invoices, set)
+        else _parse_selected_invoices(selected_invoices)
+    )
     updated = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
+    stale = 0
     batch_count = 0
     for doctype, row in _iter_invoice_rows(from_date, to_date):
-        status, change = _compute_refresh_row(doctype, row)
-        if status != "changed":
+        key = (doctype, row.name)
+        if key not in selected:
             continue
+        selected.remove(key)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Apply Failed for {0}").format(row.name)
+            )
+            continue
+        if status == "denied":
+            denied += 1
+            continue
+        if status != "changed":
+            stale += 1
+            continue
+        if change["calculation_check"] and change["calculation_check"].get(
+            "has_vat_mismatch"
+        ):
+            calculation_warnings += 1
         _apply_change(change)
         updated += 1
         batch_count += 1
@@ -202,11 +333,94 @@ def _run_apply(from_date, to_date):
     if batch_count:
         frappe.db.commit()  # nosemgrep
 
-    return updated
+    stale += len(selected)
+    return {
+        "updated": updated,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
+        "stale": stale,
+    }
 
 
-@frappe.whitelist()
-def preview_taxable_summary_refresh(from_date: str, to_date: str):
+def _csv_amount(value):
+    """Format a money field for CSV, leaving blanks when unset."""
+    return "" if value is None else flt(value, 2)
+
+
+def _calculation_check_label(change):
+    """Human-readable calculation status for a preview row."""
+    check = change.get("calculation_check") or {}
+    if check.get("has_vat_mismatch"):
+        return _("Mismatch")
+    return _("OK")
+
+
+def _change_group(change):
+    """Preview/CSV group label for a taxable-summary row."""
+    if change.get("vat_on_added_taxes"):
+        return _("Includes added taxes")
+    return _("Suggestion")
+
+
+def taxable_summary_csv_data(changes):
+    """Return CSV header plus one row per taxable-summary preview change."""
+    data = [TAXABLE_SUMMARY_CSV_COLUMNS]
+    for change in changes or []:
+        check = change.get("calculation_check") or {}
+        data.append(
+            [
+                change.get("document_type") or change.get("doctype") or "",
+                change.get("name") or "",
+                change.get("posting_date") or "",
+                change.get("company") or "",
+                _csv_amount(change.get("old_taxable_amount")),
+                _csv_amount(change.get("new_taxable_amount")),
+                _csv_amount(change.get("old_non_taxable_amount")),
+                _csv_amount(change.get("new_non_taxable_amount")),
+                _csv_amount(change.get("old_vat_amount")),
+                _csv_amount(change.get("new_vat_amount")),
+                _csv_amount(change.get("old_summary_grand_total")),
+                _csv_amount(change.get("new_summary_grand_total")),
+                _("Yes") if change.get("would_change") else _("No"),
+                _change_group(change),
+                _csv_amount(check.get("expected_vat")),
+                _csv_amount(check.get("recorded_vat")),
+                _csv_amount(check.get("vat_difference")),
+                _calculation_check_label(change),
+            ]
+        )
+    return data
+
+
+@frappe.whitelist(methods=["POST"])
+def download_taxable_summary_csv(
+    rows: list | str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+):
+    """Return a CSV file for the selected taxable-summary preview rows."""
+    _ensure_permission()
+    changes = frappe.parse_json(rows) if isinstance(rows, str) else rows
+    if not isinstance(changes, list) or not changes:
+        frappe.throw(_("Select at least one row to download."))
+
+    filename = "taxable_summary"
+    if from_date and to_date:
+        filename = f"taxable_summary_{from_date}_to_{to_date}"
+    return {
+        "filename": f"{filename}.csv",
+        "csv": to_csv(taxable_summary_csv_data(changes)),
+    }
+
+
+@frappe.whitelist(methods=["POST"])
+def preview_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Preview invoices whose taxable summary would change in the date range.
 
     Ranges larger than BATCH_SIZE run on the long queue so the HTTP worker
@@ -214,8 +428,10 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
     """
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
     scanned = _count_invoices(from_date, to_date)
     if scanned > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_preview",
             queue="long",
@@ -223,28 +439,48 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
         return {
             "queued": True,
-            "updated": 0,
             "scanned": scanned,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         }
-    return _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, consider_is_non_taxable_item
+    )
+    preview["request_id"] = request_id
+    return preview
 
 
-@frappe.whitelist()
-def apply_taxable_summary_refresh(from_date: str, to_date: str):
+@frappe.whitelist(methods=["POST"])
+def apply_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices: list | str | None = None,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Apply recomputed taxable summary values, enqueueing ranges above BATCH_SIZE."""
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
-    scanned = _count_invoices(from_date, to_date)
-    if not scanned:
-        return {"queued": False, "updated": 0, "scanned": 0}
+    selected = _parse_selected_invoices(selected_invoices or [])
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
+    if not selected:
+        return {
+            "queued": False,
+            "updated": 0,
+            "scanned": 0,
+            "request_id": request_id,
+        }
 
-    if scanned > BATCH_SIZE:
+    if len(selected) > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_refresh",
             queue="long",
@@ -252,37 +488,81 @@ def apply_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            selected_invoices=[
+                {"doctype": doctype, "name": name}
+                for doctype, name in sorted(selected)
+            ],
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
-        return {"queued": True, "updated": 0, "scanned": scanned}
+        return {
+            "queued": True,
+            "updated": 0,
+            "scanned": len(selected),
+            "request_id": request_id,
+        }
 
-    updated = _run_apply(from_date, to_date)
-    return {"queued": False, "updated": updated, "scanned": scanned}
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected,
+        consider_is_non_taxable_item,
+    )
+    return {
+        "queued": False,
+        "scanned": len(selected),
+        "request_id": request_id,
+        **result,
+    }
 
 
-def run_taxable_summary_preview(from_date: str, to_date: str):
+def run_taxable_summary_preview(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background preview scan; publishes taxable_summary_preview_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    preview = _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, bool(consider_is_non_taxable_item)
+    )
+    preview["request_id"] = request_id
     frappe.publish_realtime(
         "taxable_summary_preview_done",
         preview,
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
     return preview
 
 
-def run_taxable_summary_refresh(from_date: str, to_date: str):
+def run_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background apply; publishes taxable_summary_refresh_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    updated = _run_apply(from_date, to_date)
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected_invoices,
+        bool(consider_is_non_taxable_item),
+    )
     frappe.publish_realtime(
         "taxable_summary_refresh_done",
         {
-            "updated": updated,
+            **result,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         },
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
-    return updated
+    return result

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,0 +1,239 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from nepal_compliance import utils
+
+
+class TestTaxableSummaryCalculation(unittest.TestCase):
+    def make_invoice(self, taxable_vat=544.61):
+        return frappe._dict(
+            doctype="Purchase Invoice",
+            company="Yarsa Labs",
+            grand_total=32762.94,
+            items=[
+                frappe._dict(
+                    item_code="Taxable",
+                    net_amount=4189.33,
+                    is_nontaxable_item=0,
+                ),
+                frappe._dict(
+                    item_code="Non-Taxable",
+                    net_amount=28029,
+                    is_nontaxable_item=1,
+                ),
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Payable",
+                    tax_amount_after_discount_amount=taxable_vat,
+                    tax_amount=taxable_vat,
+                    item_wise_tax_detail=json.dumps(
+                        {"Taxable": [13, taxable_vat]}
+                    ),
+                    add_deduct_tax="Add",
+                    is_tax_withholding_account=0,
+                )
+            ],
+        )
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_csv_example_uses_non_taxable_item_flag(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice()
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 4189.33)
+        self.assertEqual(invoice.non_taxable_amount, 28029)
+        self.assertEqual(invoice.vat_amount, 544.61)
+        self.assertEqual(invoice.summary_grand_total, 32762.94)
+        self.assertEqual(check["expected_vat"], 544.61)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_mismatch_retains_recorded_vat(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=500)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.vat_amount, 500)
+        self.assertEqual(check["expected_vat"], 544.61)
+        self.assertEqual(check["vat_difference"], -44.61)
+        self.assertTrue(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_pan_bill_makes_every_item_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+        invoice.is_pan_or_abbreviated_bill = 1
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_purchase_invoice_without_tax_rows_is_fully_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+        invoice.taxes = []
+        invoice.grand_total = 32218.33
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(invoice.vat_amount, 0)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_purchase_invoice_with_zero_vat_is_fully_non_taxable(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=0)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 0)
+        self.assertEqual(invoice.non_taxable_amount, 32218.33)
+        self.assertEqual(invoice.vat_amount, 0)
+        self.assertEqual(check["expected_vat"], 0)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_sub_paisa_difference_is_within_rounding_tolerance(self, configured):
+        configured.return_value = {
+            "Yarsa Labs": {"purchase": "VAT Payable", "sales": "VAT Payable"}
+        }
+        invoice = self.make_invoice(taxable_vat=544.614)
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_vat_on_previous_row_is_detected(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                ),
+            ],
+        )
+
+        self.assertTrue(utils.vat_charged_on_added_taxes(invoice))
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_on_net_total_vat_is_not_added_taxes(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Net Total",
+                ),
+            ],
+        )
+
+        self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_previous_row_vat_includes_excise_in_taxable_base(self, configured):
+        configured.return_value = {
+            "ACME": {"sales": "VAT Payable", "purchase": "VAT Receivable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=5753.9318,
+            items=[
+                frappe._dict(
+                    item_code="Y101642",
+                    net_amount=4849.5,
+                    is_nontaxable_item=0,
+                )
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                    tax_amount=0,
+                    tax_amount_after_discount_amount=0,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [0.0, 0.0]},
+                ),
+                frappe._dict(
+                    account_head="Excise",
+                    charge_type="On Previous Row Total",
+                    tax_amount=242.475,
+                    tax_amount_after_discount_amount=242.475,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [5.0, 242.475]},
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                    tax_amount=661.9568,
+                    tax_amount_after_discount_amount=661.9568,
+                    add_deduct_tax="Add",
+                    item_wise_tax_detail={"Y101642": [13.0, 661.95675]},
+                ),
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 5091.98)
+        self.assertEqual(invoice.non_taxable_amount, 0)
+        self.assertEqual(check["expected_vat"], 661.96)
+        self.assertEqual(check["recorded_vat"], 661.96)
+        self.assertFalse(check["has_vat_mismatch"])
+        self.assertTrue(check["vat_on_added_taxes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,10 +1,10 @@
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import frappe
 
-from nepal_compliance import utils
+from nepal_compliance import taxable_summary, utils
 
 
 class TestTaxableSummaryCalculation(unittest.TestCase):
@@ -233,6 +233,242 @@ class TestTaxableSummaryCalculation(unittest.TestCase):
         self.assertEqual(check["recorded_vat"], 661.96)
         self.assertFalse(check["has_vat_mismatch"])
         self.assertTrue(check["vat_on_added_taxes"])
+
+
+class TestSelectableTaxableSummary(unittest.TestCase):
+    def test_document_types_separate_invoices_and_returns(self):
+        self.assertEqual(
+            taxable_summary._document_type("Sales Invoice", 0),
+            "Sales Invoice",
+        )
+        self.assertEqual(
+            taxable_summary._document_type("Sales Invoice", 1),
+            "Sales Return",
+        )
+        self.assertEqual(
+            taxable_summary._document_type("Purchase Invoice", 0),
+            "Purchase Invoice",
+        )
+        self.assertEqual(
+            taxable_summary._document_type("Purchase Invoice", 1),
+            "Purchase Return",
+        )
+
+    def test_refresh_endpoints_are_post_only(self):
+        allowed = frappe.allowed_http_methods_for_whitelisted_func
+        self.assertEqual(
+            allowed[taxable_summary.preview_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.apply_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.download_taxable_summary_csv], ["POST"]
+        )
+
+    @patch("nepal_compliance.taxable_summary.frappe.db.commit")
+    @patch("nepal_compliance.taxable_summary._apply_change")
+    @patch("nepal_compliance.taxable_summary._compute_refresh_row")
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows")
+    def test_apply_updates_only_selected_invoice(
+        self, iter_rows, compute, apply_change, _commit
+    ):
+        selected_row = frappe._dict(name="PINV-1")
+        other_row = frappe._dict(name="PINV-2")
+        iter_rows.return_value = iter(
+            [
+                ("Purchase Invoice", selected_row),
+                ("Purchase Invoice", other_row),
+            ]
+        )
+        change = {
+            "calculation_check": {
+                "has_vat_mismatch": True,
+            }
+        }
+        compute.return_value = ("changed", change)
+
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Purchase Invoice", "name": "PINV-1"}],
+            True,
+        )
+
+        compute.assert_called_once_with("Purchase Invoice", selected_row, True)
+        apply_change.assert_called_once_with(change)
+        self.assertEqual(result["updated"], 1)
+        self.assertEqual(result["calculation_warnings"], 1)
+
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows", return_value=iter([]))
+    def test_missing_selection_is_reported_as_stale(self, _iter_rows):
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Sales Invoice", "name": "SINV-MISSING"}],
+            True,
+        )
+
+        self.assertEqual(result["updated"], 0)
+        self.assertEqual(result["stale"], 1)
+
+    @patch("nepal_compliance.taxable_summary.enqueue")
+    @patch("nepal_compliance.taxable_summary._count_invoices", return_value=501)
+    @patch("nepal_compliance.taxable_summary._resolve_dates")
+    @patch("nepal_compliance.taxable_summary._ensure_permission")
+    def test_background_preview_propagates_option_and_request(
+        self, _permission, resolve_dates, _count, enqueue
+    ):
+        resolve_dates.return_value = ("2026-01-01", "2026-12-31")
+
+        result = taxable_summary.preview_taxable_summary_refresh(
+            "2026-01-01",
+            "2026-12-31",
+            consider_is_non_taxable_item=1,
+            request_id="preview-request",
+        )
+
+        self.assertTrue(result["queued"])
+        self.assertEqual(result["request_id"], "preview-request")
+        self.assertTrue(enqueue.call_args.kwargs["consider_is_non_taxable_item"])
+        self.assertEqual(
+            enqueue.call_args.kwargs["request_id"], "preview-request"
+        )
+
+    @patch("nepal_compliance.taxable_summary.frappe.get_doc")
+    @patch("nepal_compliance.taxable_summary.frappe.db.set_value")
+    def test_comment_includes_old_and_new_bill_total(self, _set_value, get_doc):
+        doc = Mock()
+        get_doc.return_value = doc
+        change = {
+            "doctype": "Purchase Invoice",
+            "name": "PINV-1",
+            "old_taxable_amount": 0,
+            "new_taxable_amount": 100,
+            "old_non_taxable_amount": 100,
+            "new_non_taxable_amount": 0,
+            "old_vat_amount": 13,
+            "new_vat_amount": 13,
+            "old_summary_grand_total": 113,
+            "new_summary_grand_total": 113,
+            "summary_grand_total": 113,
+            "item_vat_detail": None,
+            "calculation_check": None,
+        }
+
+        taxable_summary._apply_change(change)
+
+        comment = doc.add_comment.call_args.args[1]
+        self.assertIn("Bill Total: 113.0 → 113.0", comment)
+
+    def test_csv_includes_selected_preview_rows(self):
+        data = taxable_summary.taxable_summary_csv_data(
+            [
+                {
+                    "document_type": "Purchase Invoice",
+                    "doctype": "Purchase Invoice",
+                    "name": "YTPI-2083/84-00268",
+                    "posting_date": "2026-08-24",
+                    "company": "Yarsa Tech Pvt. Ltd.",
+                    "old_taxable_amount": 4849.5,
+                    "new_taxable_amount": 4849.5,
+                    "old_non_taxable_amount": 0,
+                    "new_non_taxable_amount": 0,
+                    "old_vat_amount": 661.96,
+                    "new_vat_amount": 661.96,
+                    "old_summary_grand_total": 5753.93,
+                    "new_summary_grand_total": 5753.93,
+                    "would_change": False,
+                    "vat_on_added_taxes": True,
+                    "calculation_check": {
+                        "expected_vat": 630.44,
+                        "recorded_vat": 661.96,
+                        "vat_difference": 31.52,
+                        "has_vat_mismatch": True,
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(data[0], taxable_summary.TAXABLE_SUMMARY_CSV_COLUMNS)
+        self.assertEqual(data[1][1], "YTPI-2083/84-00268")
+        self.assertEqual(data[1][13], "Includes added taxes")
+        self.assertEqual(data[1][17], "Mismatch")
+
+    @patch("nepal_compliance.taxable_summary._ensure_permission")
+    def test_csv_download_requires_selected_rows(self, _permission):
+        with self.assertRaises(frappe.ValidationError):
+            taxable_summary.download_taxable_summary_csv([])
+
+    @patch("nepal_compliance.taxable_summary.frappe.has_permission", return_value=True)
+    @patch("nepal_compliance.taxable_summary.frappe.get_doc")
+    @patch("nepal_compliance.taxable_summary.set_taxable_amounts")
+    def test_previous_row_vat_can_be_applied(self, set_summary, get_doc, _perm):
+        doc = frappe._dict(
+            doctype="Purchase Invoice",
+            taxable_amount=5091.98,
+            non_taxable_amount=0,
+            vat_amount=661.96,
+            summary_grand_total=5753.93,
+            item_vat_detail=None,
+            taxes=[],
+        )
+        get_doc.return_value = doc
+
+        def mutate(invoice, _method, consider_is_non_taxable_item=False):
+            invoice.taxable_amount = 5091.98
+            return {
+                "expected_vat": 661.96,
+                "recorded_vat": 661.96,
+                "vat_difference": 0,
+                "has_vat_mismatch": False,
+                "vat_on_added_taxes": True,
+            }
+
+        set_summary.side_effect = mutate
+        row = frappe._dict(
+            name="YTPI-1",
+            company="ACME",
+            posting_date="2026-08-24",
+            is_return=0,
+            taxable_amount=4849.5,
+            non_taxable_amount=0,
+            vat_amount=661.96,
+            summary_grand_total=5753.93,
+        )
+
+        status, change = taxable_summary._compute_refresh_row(
+            "Purchase Invoice", row, True
+        )
+
+        self.assertEqual(status, "changed")
+        self.assertTrue(change["would_change"])
+        self.assertEqual(change["new_taxable_amount"], 5091.98)
+
+    @patch("nepal_compliance.taxable_summary.frappe.db.commit")
+    @patch("nepal_compliance.taxable_summary._apply_change")
+    @patch("nepal_compliance.taxable_summary._compute_refresh_row")
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows")
+    def test_apply_updates_previous_row_vat_invoice(
+        self, iter_rows, compute, apply_change, _commit
+    ):
+        row = frappe._dict(name="YTPI-1")
+        iter_rows.return_value = iter([("Purchase Invoice", row)])
+        change = {
+            "vat_on_added_taxes": True,
+            "calculation_check": {"has_vat_mismatch": False},
+        }
+        compute.return_value = ("changed", change)
+
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Purchase Invoice", "name": "YTPI-1"}],
+            True,
+        )
+
+        apply_change.assert_called_once_with(change)
+        self.assertEqual(result["updated"], 1)
 
 
 if __name__ == "__main__":

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -236,6 +236,28 @@ def tax_row_amount(tax):
         else tax.tax_amount
     )
 
+PREVIOUS_ROW_VAT_CHARGE_TYPES = ("On Previous Row Total", "On Previous Row Amount")
+
+
+def vat_charged_on_added_taxes(doc, vat_account=None):
+    """True when VAT is calculated on a previous tax row (duty, excise, etc.).
+
+    Item-net × 13% is not the VAT base in that stack, so Taxable Summary
+    Refresh must not rewrite these invoices from the itemwise check.
+    """
+    if doc.doctype not in ("Sales Invoice", "Purchase Invoice"):
+        return False
+    if not vat_account:
+        side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+        vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+    if not vat_account:
+        return False
+    return any(
+        tax.account_head == vat_account
+        and tax.charge_type in PREVIOUS_ROW_VAT_CHARGE_TYPES
+        for tax in (doc.get("taxes") or [])
+    )
+
 VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
 
 def get_configured_vat_accounts():
@@ -379,7 +401,13 @@ def validate_duplicate_bill_no(doc, method):
                 )
             )
 
-def set_taxable_amounts(doc, method):
+def set_taxable_amounts(doc, method, consider_is_non_taxable_item=False):
+    """Set IRD taxable summary fields and return an optional VAT calculation check.
+
+    The normal document-event path keeps the historical item-wise VAT
+    classification. The settings recompute can instead classify items solely
+    from the item's Is Non-Taxable Item flag.
+    """
     side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
     vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
 
@@ -389,26 +417,39 @@ def set_taxable_amounts(doc, method):
         for tax in doc.get("taxes") or []:
             if tax.account_head != vat_account:
                 continue
-            vat_amount += flt(
-                tax.tax_amount_after_discount_amount
-                if tax.tax_amount_after_discount_amount is not None
-                else tax.tax_amount
-            )
-            detail = tax.item_wise_tax_detail
-            if isinstance(detail, str):
-                try:
-                    detail = json.loads(detail)
-                except (TypeError, ValueError):
-                    detail = {}
-            for item_key, rate_amount in (detail or {}).items():
-                if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
-                    item_vat[item_key] = item_vat.get(item_key, 0.0) + flt(rate_amount[1])
+            vat_amount += tax_row_amount(tax)
+            add_item_wise_vat(item_vat, tax.item_wise_tax_detail)
+
+    items = list(doc.get("items") or [])
+    row_vat = distribute_item_vat(items, item_vat)
+    include_added_taxes = vat_charged_on_added_taxes(doc, vat_account)
 
     taxable_amount = non_taxable_amount = 0.0
-    for item in doc.get("items") or []:
+    force_all_non_taxable = bool(
+        doc.get("is_pan_or_abbreviated_bill")
+        or (
+            doc.doctype == "Purchase Invoice"
+            and (not doc.get("taxes") or not flt(vat_amount))
+        )
+    )
+    for item, item_row_vat in zip(items, row_vat, strict=True):
         amt = flt(item.get("net_amount"))
-        if item.get("is_nontaxable_item") or not flt(item_vat.get(item.get("item_code") or item.get("item_name"))):
+        if consider_is_non_taxable_item:
+            is_non_taxable = bool(
+                force_all_non_taxable or item.get("is_nontaxable_item")
+            )
+        else:
+            item_key = item.get("item_code") or item.get("item_name")
+            is_non_taxable = bool(
+                item.get("is_nontaxable_item")
+                or not flt(parse_item_vat_entry(item_vat.get(item_key))[1])
+            )
+        if is_non_taxable:
             non_taxable_amount += amt
+        elif include_added_taxes:
+            # VAT was charged on net + prior rows (duty/excise). Use VAT ÷ rate
+            # so expected VAT is 13% of that same base.
+            taxable_amount += item_taxable_amount(item, item_row_vat, item_vat)
         else:
             taxable_amount += amt
 
@@ -418,6 +459,20 @@ def set_taxable_amounts(doc, method):
     # Bill Total is grand_total plus TDS: ERPNext deducts TDS from grand_total,
     # IRD wants the billed value (net + VAT) before withholding.
     set_bill_total(doc, vat_account)
+
+    if not consider_is_non_taxable_item:
+        return None
+
+    expected_vat = flt(taxable_amount * 0.13, 2)
+    recorded_vat = flt(vat_amount, 2)
+    difference = flt(recorded_vat - expected_vat, 2)
+    return {
+        "expected_vat": expected_vat,
+        "recorded_vat": recorded_vat,
+        "vat_difference": difference,
+        "has_vat_mismatch": abs(difference) >= 0.01,
+        "vat_on_added_taxes": include_added_taxes,
+    }
 
 def get_vat_breakup(invoice_doctype, invoice_company_map):
     """


### PR DESCRIPTION
## Recompute Taxable Summary (IRD Report Related Changes)
- Preview and apply only the invoices you select, including document-type filter and CSV download of selected rows.
- Add the Consider Is Non-Taxable Item option and help text for duty/excise VAT base.
- Restrict preview, apply, and CSV download to POST, with whitelist type hints for the Frappe linter.

Split from #351 (2/4). **Depends on #352 — merge that first.** Until then this PR also contains the VAT-base commit.

## Test plan
- [ ] Preview a date range, select a subset, Apply; unselected invoices stay unchanged.
- [ ] Download CSV for the selected rows.
- [ ] GET is rejected for preview/apply/CSV; Desk POST still works.