### PR TITLE
feat(ird): explain taxable summary recompute options

### DIFF
--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -256,7 +256,13 @@ function show_preview_dialog(preview, values) {
 		primary_action() {
 			dialog.hide();
 			if (preview.changed) {
-				run_apply(values);
+				run_apply(
+					values,
+					preview.changes.map((row) => ({
+						doctype: row.doctype,
+						name: row.name,
+					}))
+				);
 			}
 		},
 	});
@@ -310,7 +316,7 @@ function listen_for_refresh_done() {
 	});
 }
 
-function run_apply(values) {
+function run_apply(values, selected_invoices) {
 	frappe._taxable_summary_apply_pending = frappe._taxable_summary_apply_pending || {};
 	const already_running = Object.values(frappe._taxable_summary_apply_pending).some(
 		(pending) =>
@@ -328,6 +334,7 @@ function run_apply(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			selected_invoices: JSON.stringify(selected_invoices),
 			request_id: request_id,
 		},
 		freeze: true,

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -21,6 +21,15 @@ function open_date_prompt() {
 		title: __("Recompute Taxable Summary"),
 		fields: [
 			{
+				fieldname: "recompute_help_button",
+				fieldtype: "HTML",
+				options: `<div class="text-right">
+					<button type="button" class="btn btn-xs btn-default recompute-help" title="${__(
+						"About Recompute Taxable Summary"
+					)}">?</button>
+				</div>`,
+			},
+			{
 				fieldname: "fiscal_year",
 				fieldtype: "Link",
 				options: "Fiscal Year",
@@ -56,11 +65,20 @@ function open_date_prompt() {
 				reqd: 1,
 			},
 			{
+				fieldname: "consider_is_non_taxable_item",
+				fieldtype: "Check",
+				label: __("Consider Is Non-Taxable Item"),
+				default: 0,
+				description: __(
+					"Classify flagged item rows as non-taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT."
+				),
+			},
+			{
 				fieldname: "help",
 				fieldtype: "HTML",
 				options: `<p class="text-muted">
 					${__(
-						"Select a Fiscal Year to fill the dates, or enter a posting date range. Only submitted Sales and Purchase Invoices in this range will be scanned."
+						"Only submitted Sales and Purchase Invoices in this range will be scanned. VAT calculation mismatches are warnings; VAT recorded in invoice tax rows is retained."
 					)}
 				</p>`,
 			},
@@ -76,6 +94,34 @@ function open_date_prompt() {
 		},
 	});
 	dialog.show();
+	dialog.fields_dict.recompute_help_button.$wrapper
+		.find(".recompute-help")
+		.on("click", show_taxable_summary_help);
+}
+
+function show_taxable_summary_help() {
+	frappe.msgprint({
+		title: __("About Recompute Taxable Summary"),
+		message: `
+			<p>${__(
+				"Use this tool to preview and correct the Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and item VAT summary stored on submitted Sales and Purchase Invoices. You can select which suggestions to apply."
+			)}</p>
+			<p><b>${__("Example")}</b></p>
+			<ul>
+				<li>${__("Taxable item total")}: ${fmt(4189.33)}</li>
+				<li>${__("Non-taxable item total")}: ${fmt(28029)}</li>
+				<li>${__("Expected VAT")}: ${fmt(4189.33)} × 13% = ${fmt(544.61)}</li>
+				<li>${__("Bill Total")}: ${fmt(32218.33)} + ${fmt(544.61)} = ${fmt(32762.94)}</li>
+			</ul>
+			<p>${__(
+				"If Is PAN/Abbreviated Bill is checked, a Purchase Invoice has no Taxes and Charges rows, or its recorded VAT is zero, all its items are treated as non-taxable and expected VAT is zero."
+			)}</p>
+			<p>${__(
+				"If VAT is charged on a previous tax row (import duty, excise, or similar), taxable value is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%."
+			)}</p>
+		`,
+		indicator: "blue",
+	});
 }
 
 function listen_for_preview_done() {
@@ -124,6 +170,7 @@ function run_preview(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,
@@ -328,6 +375,7 @@ function run_apply(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,

--- a/nepal_compliance/nepali_date_utils/bs_periods.py
+++ b/nepal_compliance/nepali_date_utils/bs_periods.py
@@ -23,16 +23,26 @@ def end_of(y, m):
     return bs_to_ad(y, m, days_in_bs_month(y, m))
 
 
+def is_fiscal_period_month(y, m, freq):
+    """Return whether a BS month closes a continuous Ashadh-anchored period."""
+    freq = max(cint(freq), 1)
+    month_index = y * 12 + (m - 1)
+    ashadh_index = 2
+    return (month_index - ashadh_index) % freq == 0
+
+
 def next_fiscal_period_end(y, m, freq):
     """First BS month on or after (y, m) that ends a Nepali fiscal period.
 
     The Nepali fiscal year runs 1 Shrawan to end of Ashadh (months 4..3), so a
-    month closes a fiscal period exactly when (m - 3) % freq == 0:
+    continuous month offset from Ashadh determines each period end:
     monthly (1) -> every month; quarterly (3) -> Ashwin/Poush/Chaitra/Ashadh;
     half-yearly (6) -> Poush/Ashadh; yearly (12) -> Ashadh (FY end).
+    Including the BS year keeps arbitrary ERPNext frequencies consistent when
+    a period crosses a year boundary.
     """
     freq = max(cint(freq), 1)
-    while (m - 3) % freq != 0:
+    while not is_fiscal_period_month(y, m, freq):
         y, m = advance(y, m, 1)
     return y, m
 

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -1,12 +1,11 @@
 import frappe
 from frappe import _
-from frappe.utils import flt, getdate
+from frappe.utils import cint, flt, getdate
 from frappe.utils.background_jobs import enqueue
 
 from nepal_compliance.utils import set_taxable_amounts
 
 BATCH_SIZE = 500
-PREVIEW_TABLE_LIMIT = 100
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
 
 
@@ -49,6 +48,7 @@ def _iter_invoice_rows(from_date, to_date):
         "name",
         "company",
         "posting_date",
+        "is_return",
         "taxable_amount",
         "non_taxable_amount",
         "vat_amount",
@@ -74,6 +74,14 @@ def _iter_invoice_rows(from_date, to_date):
             start += BATCH_SIZE
 
 
+SUMMARY_COMPARE_FIELDS = (
+    "taxable_amount",
+    "non_taxable_amount",
+    "vat_amount",
+    "summary_grand_total",
+)
+
+
 def _amt(value):
     """Round a money field to 2 decimals, preserving None."""
     return None if value is None else flt(value, 2)
@@ -81,29 +89,49 @@ def _amt(value):
 
 def _figures_changed(old, new):
     """True when taxable, non-taxable, VAT, or Bill Total would change."""
-    return (
-        _amt(old.taxable_amount) != _amt(new.taxable_amount)
-        or _amt(old.non_taxable_amount) != _amt(new.non_taxable_amount)
-        or _amt(old.vat_amount) != _amt(new.vat_amount)
-        or _amt(old.summary_grand_total) != _amt(new.summary_grand_total)
+    return any(
+        _amt(old.get(field)) != _amt(new.get(field))
+        for field in SUMMARY_COMPARE_FIELDS
     )
 
 
-def _compute_refresh_row(doctype, row):
+def _document_type(doctype, is_return):
+    if not is_return:
+        return doctype
+    return "Sales Return" if doctype == "Sales Invoice" else "Purchase Return"
+
+
+def _compute_refresh_row(doctype, row, consider_is_non_taxable_item=False):
     """Recompute one invoice's taxable summary and classify the result."""
     doc = frappe.get_doc(doctype, row.name)
-    set_taxable_amounts(doc, None)
+    if not frappe.has_permission(doctype, "write", doc=doc):
+        return "denied", None
+
+    calculation_check = set_taxable_amounts(
+        doc,
+        None,
+        consider_is_non_taxable_item=consider_is_non_taxable_item,
+    )
     if doc.get("taxable_amount") is None:
         return "skipped", None
 
-    if not _figures_changed(row, doc):
+    figures_changed = _figures_changed(row, doc)
+    has_warning = bool(
+        calculation_check and calculation_check.get("has_vat_mismatch")
+    )
+    if not figures_changed and not has_warning:
         return "unchanged", None
 
-    return "changed", {
+    return ("changed" if figures_changed else "warning"), {
         "doctype": doctype,
+        "document_type": _document_type(doctype, row.get("is_return")),
         "name": row.name,
         "company": row.company,
         "posting_date": str(row.posting_date),
+        "would_change": figures_changed,
+        "vat_on_added_taxes": bool(
+            calculation_check and calculation_check.get("vat_on_added_taxes")
+        ),
         "old_taxable_amount": _amt(row.taxable_amount),
         "new_taxable_amount": _amt(doc.taxable_amount),
         "old_non_taxable_amount": _amt(row.non_taxable_amount),
@@ -113,31 +141,48 @@ def _compute_refresh_row(doctype, row):
         "old_summary_grand_total": _amt(row.summary_grand_total),
         "new_summary_grand_total": _amt(doc.summary_grand_total),
         "summary_grand_total": doc.summary_grand_total,
-        "item_vat_detail": doc.item_vat_detail,
+        "item_vat_detail": doc.get("item_vat_detail"),
+        "calculation_check": calculation_check,
     }
 
 
-def _scan_changes(from_date, to_date):
+def _scan_changes(from_date, to_date, consider_is_non_taxable_item=False):
     """Scan invoices in range and return preview rows plus counts."""
     scanned = 0
     unchanged = 0
     skipped = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
     by_doctype = {doctype: 0 for doctype in DOCTYPE_ORDER}
     changes = []
 
     for doctype, row in _iter_invoice_rows(from_date, to_date):
         scanned += 1
-        status, change = _compute_refresh_row(doctype, row)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Preview Failed for {0}").format(row.name)
+            )
+            continue
         if status == "skipped":
             skipped += 1
+        elif status == "denied":
+            denied += 1
         elif status == "unchanged":
             unchanged += 1
         else:
-            by_doctype[doctype] += 1
-            if len(changes) < PREVIEW_TABLE_LIMIT:
-                changes.append(
-                    {k: change[k] for k in change if k != "item_vat_detail"}
-                )
+            if change["calculation_check"] and change["calculation_check"].get(
+                "has_vat_mismatch"
+            ):
+                calculation_warnings += 1
+            if status == "changed":
+                by_doctype[doctype] += 1
+            changes.append({k: change[k] for k in change if k != "item_vat_detail"})
 
     changed = sum(by_doctype.values())
     return {
@@ -148,11 +193,14 @@ def _scan_changes(from_date, to_date):
         "changed": changed,
         "unchanged": unchanged,
         "skipped": skipped,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
         "sales_changed": by_doctype["Sales Invoice"],
         "purchase_changed": by_doctype["Purchase Invoice"],
         "batched": scanned > BATCH_SIZE,
         "changes": changes,
-        "hidden_rows": max(changed - len(changes), 0),
+        "consider_is_non_taxable_item": bool(consider_is_non_taxable_item),
     }
 
 
@@ -174,25 +222,87 @@ def _apply_change(change):
     doc.add_comment(
         "Comment",
         _(
-            "Nepal Compliance: taxable summary recomputed from VAT base "
-            "(VAT ÷ rate). Taxable: {0}, Non-Taxable: {1}, VAT: {2}, Bill Total: {3}"
+            "Nepal Compliance: taxable summary recomputed. "
+            "Taxable: {0} → {1}, Non-Taxable: {2} → {3}, "
+            "VAT: {4} → {5}, Bill Total: {6} → {7}."
         ).format(
+            flt(change["old_taxable_amount"], 2),
             flt(change["new_taxable_amount"], 2),
+            flt(change["old_non_taxable_amount"], 2),
             flt(change["new_non_taxable_amount"], 2),
+            flt(change["old_vat_amount"], 2),
             flt(change["new_vat_amount"], 2),
+            flt(change["old_summary_grand_total"], 2),
             flt(change["new_summary_grand_total"], 2),
         ),
     )
 
 
-def _run_apply(from_date, to_date):
-    """Apply recomputed taxable summary values, committing every BATCH_SIZE invoices."""
+def _parse_selected_invoices(selected_invoices):
+    """Return validated selected invoice keys from a JSON/list payload."""
+    selected = (
+        frappe.parse_json(selected_invoices)
+        if isinstance(selected_invoices, str)
+        else selected_invoices
+    )
+    if not isinstance(selected, list):
+        frappe.throw(_("Selected invoices must be a list."))
+
+    keys = set()
+    for row in selected:
+        if not isinstance(row, dict):
+            frappe.throw(_("Each selected invoice must include a type and name."))
+        doctype = row.get("doctype")
+        name = row.get("name")
+        if doctype not in DOCTYPE_ORDER or not name:
+            frappe.throw(_("Invalid selected invoice: {0} {1}").format(doctype, name))
+        keys.add((doctype, name))
+    return keys
+
+
+def _run_apply(
+    from_date,
+    to_date,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+):
+    """Apply selected recomputed values, committing every BATCH_SIZE invoices."""
+    selected = (
+        set(selected_invoices)
+        if isinstance(selected_invoices, set)
+        else _parse_selected_invoices(selected_invoices)
+    )
     updated = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
+    stale = 0
     batch_count = 0
     for doctype, row in _iter_invoice_rows(from_date, to_date):
-        status, change = _compute_refresh_row(doctype, row)
-        if status != "changed":
+        key = (doctype, row.name)
+        if key not in selected:
             continue
+        selected.remove(key)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Apply Failed for {0}").format(row.name)
+            )
+            continue
+        if status == "denied":
+            denied += 1
+            continue
+        if status != "changed":
+            stale += 1
+            continue
+        if change["calculation_check"] and change["calculation_check"].get(
+            "has_vat_mismatch"
+        ):
+            calculation_warnings += 1
         _apply_change(change)
         updated += 1
         batch_count += 1
@@ -202,11 +312,23 @@ def _run_apply(from_date, to_date):
     if batch_count:
         frappe.db.commit()  # nosemgrep
 
-    return updated
+    stale += len(selected)
+    return {
+        "updated": updated,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
+        "stale": stale,
+    }
 
 
-@frappe.whitelist()
-def preview_taxable_summary_refresh(from_date: str, to_date: str):
+@frappe.whitelist(methods=["POST"])
+def preview_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Preview invoices whose taxable summary would change in the date range.
 
     Ranges larger than BATCH_SIZE run on the long queue so the HTTP worker
@@ -214,8 +336,10 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
     """
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
     scanned = _count_invoices(from_date, to_date)
     if scanned > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_preview",
             queue="long",
@@ -223,28 +347,48 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
         return {
             "queued": True,
-            "updated": 0,
             "scanned": scanned,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         }
-    return _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, consider_is_non_taxable_item
+    )
+    preview["request_id"] = request_id
+    return preview
 
 
-@frappe.whitelist()
-def apply_taxable_summary_refresh(from_date: str, to_date: str):
+@frappe.whitelist(methods=["POST"])
+def apply_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices: list | str | None = None,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Apply recomputed taxable summary values, enqueueing ranges above BATCH_SIZE."""
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
-    scanned = _count_invoices(from_date, to_date)
-    if not scanned:
-        return {"queued": False, "updated": 0, "scanned": 0}
+    selected = _parse_selected_invoices(selected_invoices or [])
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
+    if not selected:
+        return {
+            "queued": False,
+            "updated": 0,
+            "scanned": 0,
+            "request_id": request_id,
+        }
 
-    if scanned > BATCH_SIZE:
+    if len(selected) > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_refresh",
             queue="long",
@@ -252,37 +396,81 @@ def apply_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            selected_invoices=[
+                {"doctype": doctype, "name": name}
+                for doctype, name in sorted(selected)
+            ],
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
-        return {"queued": True, "updated": 0, "scanned": scanned}
+        return {
+            "queued": True,
+            "updated": 0,
+            "scanned": len(selected),
+            "request_id": request_id,
+        }
 
-    updated = _run_apply(from_date, to_date)
-    return {"queued": False, "updated": updated, "scanned": scanned}
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected,
+        consider_is_non_taxable_item,
+    )
+    return {
+        "queued": False,
+        "scanned": len(selected),
+        "request_id": request_id,
+        **result,
+    }
 
 
-def run_taxable_summary_preview(from_date: str, to_date: str):
+def run_taxable_summary_preview(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background preview scan; publishes taxable_summary_preview_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    preview = _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, bool(consider_is_non_taxable_item)
+    )
+    preview["request_id"] = request_id
     frappe.publish_realtime(
         "taxable_summary_preview_done",
         preview,
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
     return preview
 
 
-def run_taxable_summary_refresh(from_date: str, to_date: str):
+def run_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background apply; publishes taxable_summary_refresh_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    updated = _run_apply(from_date, to_date)
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected_invoices,
+        bool(consider_is_non_taxable_item),
+    )
     frappe.publish_realtime(
         "taxable_summary_refresh_done",
         {
-            "updated": updated,
+            **result,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         },
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
-    return updated
+    return result

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -2,11 +2,32 @@ import frappe
 from frappe import _
 from frappe.utils import cint, flt, getdate
 from frappe.utils.background_jobs import enqueue
+from frappe.utils.csvutils import to_csv
 
 from nepal_compliance.utils import set_taxable_amounts
 
 BATCH_SIZE = 500
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
+TAXABLE_SUMMARY_CSV_COLUMNS = [
+    "Type",
+    "Invoice",
+    "Posting Date",
+    "Company",
+    "Taxable (Old)",
+    "Taxable (New)",
+    "Non-Taxable (Old)",
+    "Non-Taxable (New)",
+    "VAT (Old)",
+    "VAT (New)",
+    "Bill Total (Old)",
+    "Bill Total (New)",
+    "Would Change",
+    "Group",
+    "Expected VAT",
+    "Recorded VAT",
+    "Difference",
+    "Calculation Check",
+]
 
 
 def _ensure_permission():
@@ -319,6 +340,64 @@ def _run_apply(
         "failed": failed,
         "calculation_warnings": calculation_warnings,
         "stale": stale,
+    }
+
+
+def _csv_amount(value):
+    """Format a money field for CSV, leaving blanks when unset."""
+    return "" if value is None else flt(value, 2)
+
+
+def taxable_summary_csv_data(changes):
+    """Return CSV header plus one row per taxable-summary preview change."""
+    data = [TAXABLE_SUMMARY_CSV_COLUMNS]
+    for change in changes or []:
+        check = change.get("calculation_check") or {}
+        data.append(
+            [
+                change.get("document_type") or change.get("doctype") or "",
+                change.get("name") or "",
+                change.get("posting_date") or "",
+                change.get("company") or "",
+                _csv_amount(change.get("old_taxable_amount")),
+                _csv_amount(change.get("new_taxable_amount")),
+                _csv_amount(change.get("old_non_taxable_amount")),
+                _csv_amount(change.get("new_non_taxable_amount")),
+                _csv_amount(change.get("old_vat_amount")),
+                _csv_amount(change.get("new_vat_amount")),
+                _csv_amount(change.get("old_summary_grand_total")),
+                _csv_amount(change.get("new_summary_grand_total")),
+                _("Yes") if change.get("would_change") else _("No"),
+                _("Includes added taxes")
+                if change.get("vat_on_added_taxes")
+                else _("Suggestion"),
+                _csv_amount(check.get("expected_vat")),
+                _csv_amount(check.get("recorded_vat")),
+                _csv_amount(check.get("vat_difference")),
+                _("Mismatch") if check.get("has_vat_mismatch") else _("OK"),
+            ]
+        )
+    return data
+
+
+@frappe.whitelist(methods=["POST"])
+def download_taxable_summary_csv(
+    rows: list | str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+):
+    """Return a CSV file for the selected taxable-summary preview rows."""
+    _ensure_permission()
+    changes = frappe.parse_json(rows) if isinstance(rows, str) else rows
+    if not isinstance(changes, list) or not changes:
+        frappe.throw(_("Select at least one row to download."))
+
+    filename = "taxable_summary"
+    if from_date and to_date:
+        filename = f"taxable_summary_{from_date}_to_{to_date}"
+    return {
+        "filename": f"{filename}.csv",
+        "csv": to_csv(taxable_summary_csv_data(changes)),
     }
 
 

--- a/nepal_compliance/test/test_bs_periods.py
+++ b/nepal_compliance/test/test_bs_periods.py
@@ -1,0 +1,27 @@
+import unittest
+
+from nepal_compliance.nepali_date_utils.bs_periods import (
+    is_fiscal_period_month,
+    next_fiscal_period_end,
+)
+from nepal_compliance.overrides.asset_depreciation_schedule import (
+    is_bs_fiscal_period_end,
+)
+
+
+class TestBSFiscalPeriods(unittest.TestCase):
+    def test_standard_fiscal_period_end_months(self):
+        self.assertTrue(is_fiscal_period_month(2083, 3, 12))
+        self.assertTrue(is_fiscal_period_month(2083, 6, 3))
+        self.assertFalse(is_fiscal_period_month(2083, 5, 3))
+
+    def test_next_period_end_uses_same_anchor(self):
+        self.assertEqual(next_fiscal_period_end(2083, 4, 3), (2083, 6))
+        self.assertEqual(next_fiscal_period_end(2083, 12, 6), (2084, 3))
+
+    def test_asset_override_imports_period_helper(self):
+        self.assertTrue(callable(is_bs_fiscal_period_end))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import frappe
 
-from nepal_compliance import utils
+from nepal_compliance import taxable_summary, utils
 
 
 class TestTaxableSummaryCalculation(unittest.TestCase):
@@ -109,6 +109,82 @@ class TestTaxableSummaryCalculation(unittest.TestCase):
         )
 
         self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+
+class TestSelectableTaxableSummary(unittest.TestCase):
+    def test_refresh_endpoints_are_post_only(self):
+        allowed = frappe.allowed_http_methods_for_whitelisted_func
+        self.assertEqual(
+            allowed[taxable_summary.preview_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.apply_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.download_taxable_summary_csv], ["POST"]
+        )
+
+    @patch("nepal_compliance.taxable_summary.frappe.db.commit")
+    @patch("nepal_compliance.taxable_summary._apply_change")
+    @patch("nepal_compliance.taxable_summary._compute_refresh_row")
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows")
+    def test_apply_updates_only_selected_invoice(
+        self, iter_rows, compute, apply_change, _commit
+    ):
+        selected_row = frappe._dict(name="PINV-1")
+        other_row = frappe._dict(name="PINV-2")
+        iter_rows.return_value = iter(
+            [
+                ("Purchase Invoice", selected_row),
+                ("Purchase Invoice", other_row),
+            ]
+        )
+        change = {"calculation_check": {"has_vat_mismatch": False}}
+        compute.return_value = ("changed", change)
+
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Purchase Invoice", "name": "PINV-1"}],
+            True,
+        )
+
+        compute.assert_called_once_with("Purchase Invoice", selected_row, True)
+        apply_change.assert_called_once_with(change)
+        self.assertEqual(result["updated"], 1)
+
+    def test_csv_contains_selected_preview_row(self):
+        data = taxable_summary.taxable_summary_csv_data(
+            [
+                {
+                    "document_type": "Purchase Invoice",
+                    "name": "YTPI-1",
+                    "posting_date": "2026-08-24",
+                    "company": "ACME",
+                    "old_taxable_amount": 4849.5,
+                    "new_taxable_amount": 5091.98,
+                    "old_non_taxable_amount": 0,
+                    "new_non_taxable_amount": 0,
+                    "old_vat_amount": 661.96,
+                    "new_vat_amount": 661.96,
+                    "old_summary_grand_total": 5753.93,
+                    "new_summary_grand_total": 5753.93,
+                    "would_change": True,
+                    "vat_on_added_taxes": True,
+                    "calculation_check": {
+                        "expected_vat": 661.96,
+                        "recorded_vat": 661.96,
+                        "vat_difference": 0,
+                        "has_vat_mismatch": False,
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(data[0], taxable_summary.TAXABLE_SUMMARY_CSV_COLUMNS)
+        self.assertEqual(data[1][1], "YTPI-1")
+        self.assertEqual(data[1][13], "Includes added taxes")
+        self.assertEqual(data[1][17], "OK")
 
 
 if __name__ == "__main__":

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from nepal_compliance import utils
+
+
+class TestTaxableSummaryCalculation(unittest.TestCase):
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_non_taxable_item_flag_classifies_item_totals(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=32762.94,
+            items=[
+                frappe._dict(
+                    item_code="Taxable", net_amount=4189.33, is_nontaxable_item=0
+                ),
+                frappe._dict(
+                    item_code="Non-Taxable",
+                    net_amount=28029,
+                    is_nontaxable_item=1,
+                ),
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    tax_amount_after_discount_amount=544.61,
+                    item_wise_tax_detail={"Taxable": [13, 544.61]},
+                )
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 4189.33)
+        self.assertEqual(invoice.non_taxable_amount, 28029)
+        self.assertEqual(invoice.vat_amount, 544.61)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_previous_row_vat_includes_excise_in_taxable_base(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=5753.9318,
+            items=[
+                frappe._dict(
+                    item_code="Y101642",
+                    net_amount=4849.5,
+                    is_nontaxable_item=0,
+                )
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                    tax_amount_after_discount_amount=0,
+                    item_wise_tax_detail={"Y101642": [0, 0]},
+                ),
+                frappe._dict(
+                    account_head="Excise",
+                    charge_type="On Previous Row Total",
+                    tax_amount_after_discount_amount=242.475,
+                    item_wise_tax_detail={"Y101642": [5, 242.475]},
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                    tax_amount_after_discount_amount=661.9568,
+                    item_wise_tax_detail={"Y101642": [13, 661.95675]},
+                ),
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 5091.98)
+        self.assertEqual(check["expected_vat"], 661.96)
+        self.assertEqual(check["recorded_vat"], 661.96)
+        self.assertFalse(check["has_vat_mismatch"])
+        self.assertTrue(check["vat_on_added_taxes"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_on_net_total_vat_does_not_include_added_taxes(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Net Total",
+                )
+            ],
+        )
+
+        self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -236,6 +236,28 @@ def tax_row_amount(tax):
         else tax.tax_amount
     )
 
+PREVIOUS_ROW_VAT_CHARGE_TYPES = ("On Previous Row Total", "On Previous Row Amount")
+
+
+def vat_charged_on_added_taxes(doc, vat_account=None):
+    """True when VAT is calculated on a previous tax row (duty, excise, etc.).
+
+    Item-net × 13% is not the VAT base in that stack, so Taxable Summary
+    Refresh must not rewrite these invoices from the itemwise check.
+    """
+    if doc.doctype not in ("Sales Invoice", "Purchase Invoice"):
+        return False
+    if not vat_account:
+        side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+        vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+    if not vat_account:
+        return False
+    return any(
+        tax.account_head == vat_account
+        and tax.charge_type in PREVIOUS_ROW_VAT_CHARGE_TYPES
+        for tax in (doc.get("taxes") or [])
+    )
+
 VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
 
 def get_configured_vat_accounts():
@@ -379,7 +401,13 @@ def validate_duplicate_bill_no(doc, method):
                 )
             )
 
-def set_taxable_amounts(doc, method):
+def set_taxable_amounts(doc, method, consider_is_non_taxable_item=False):
+    """Set IRD taxable summary fields and return an optional VAT calculation check.
+
+    The normal document-event path keeps the historical item-wise VAT
+    classification. The settings recompute can instead classify items solely
+    from the item's Is Non-Taxable Item flag.
+    """
     side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
     vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
 
@@ -389,26 +417,39 @@ def set_taxable_amounts(doc, method):
         for tax in doc.get("taxes") or []:
             if tax.account_head != vat_account:
                 continue
-            vat_amount += flt(
-                tax.tax_amount_after_discount_amount
-                if tax.tax_amount_after_discount_amount is not None
-                else tax.tax_amount
-            )
-            detail = tax.item_wise_tax_detail
-            if isinstance(detail, str):
-                try:
-                    detail = json.loads(detail)
-                except (TypeError, ValueError):
-                    detail = {}
-            for item_key, rate_amount in (detail or {}).items():
-                if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
-                    item_vat[item_key] = item_vat.get(item_key, 0.0) + flt(rate_amount[1])
+            vat_amount += tax_row_amount(tax)
+            add_item_wise_vat(item_vat, tax.item_wise_tax_detail)
+
+    items = list(doc.get("items") or [])
+    row_vat = distribute_item_vat(items, item_vat)
+    include_added_taxes = vat_charged_on_added_taxes(doc, vat_account)
 
     taxable_amount = non_taxable_amount = 0.0
-    for item in doc.get("items") or []:
+    force_all_non_taxable = bool(
+        doc.get("is_pan_or_abbreviated_bill")
+        or (
+            doc.doctype == "Purchase Invoice"
+            and (not doc.get("taxes") or not flt(vat_amount))
+        )
+    )
+    for item, item_row_vat in zip(items, row_vat, strict=True):
         amt = flt(item.get("net_amount"))
-        if item.get("is_nontaxable_item") or not flt(item_vat.get(item.get("item_code") or item.get("item_name"))):
+        if consider_is_non_taxable_item:
+            is_non_taxable = bool(
+                force_all_non_taxable or item.get("is_nontaxable_item")
+            )
+        else:
+            item_key = item.get("item_code") or item.get("item_name")
+            is_non_taxable = bool(
+                item.get("is_nontaxable_item")
+                or not flt(parse_item_vat_entry(item_vat.get(item_key))[1])
+            )
+        if is_non_taxable:
             non_taxable_amount += amt
+        elif include_added_taxes:
+            # VAT was charged on net + prior rows (duty/excise). Use VAT ÷ rate
+            # so expected VAT is 13% of that same base.
+            taxable_amount += item_taxable_amount(item, item_row_vat, item_vat)
         else:
             taxable_amount += amt
 
@@ -418,6 +459,20 @@ def set_taxable_amounts(doc, method):
     # Bill Total is grand_total plus TDS: ERPNext deducts TDS from grand_total,
     # IRD wants the billed value (net + VAT) before withholding.
     set_bill_total(doc, vat_account)
+
+    if not consider_is_non_taxable_item:
+        return None
+
+    expected_vat = flt(taxable_amount * 0.13, 2)
+    recorded_vat = flt(vat_amount, 2)
+    difference = flt(recorded_vat - expected_vat, 2)
+    return {
+        "expected_vat": expected_vat,
+        "recorded_vat": recorded_vat,
+        "vat_difference": difference,
+        "has_vat_mismatch": abs(difference) >= 0.01,
+        "vat_on_added_taxes": include_added_taxes,
+    }
 
 def get_vat_breakup(invoice_doctype, invoice_company_map):
     """


### PR DESCRIPTION
## Summary
- Add help for taxable, non-taxable, VAT, and Bill Total recomputation.
- Explain VAT bases containing duty or excise.
- Add the Consider Is Non-Taxable Item option.
- Pass the option through preview and apply requests.

Depends on #359. Merge after #359; this PR will shrink to its focused diff then.