### PR TITLE
docs(tds): add taxable base audit help

### DIFF
--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -256,7 +256,13 @@ function show_preview_dialog(preview, values) {
 		primary_action() {
 			dialog.hide();
 			if (preview.changed) {
-				run_apply(values);
+				run_apply(
+					values,
+					preview.changes.map((row) => ({
+						doctype: row.doctype,
+						name: row.name,
+					}))
+				);
 			}
 		},
 	});
@@ -310,7 +316,7 @@ function listen_for_refresh_done() {
 	});
 }
 
-function run_apply(values) {
+function run_apply(values, selected_invoices) {
 	frappe._taxable_summary_apply_pending = frappe._taxable_summary_apply_pending || {};
 	const already_running = Object.values(frappe._taxable_summary_apply_pending).some(
 		(pending) =>
@@ -328,6 +334,7 @@ function run_apply(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			selected_invoices: JSON.stringify(selected_invoices),
 			request_id: request_id,
 		},
 		freeze: true,

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -606,6 +606,15 @@ function open_tds_base_prompt() {
 		title: __("Audit TDS Bases"),
 		fields: [
 			{
+				fieldname: "tds_help_button",
+				fieldtype: "HTML",
+				options: `<div class="text-right">
+					<button type="button" class="btn btn-xs btn-default tds-base-help" title="${__(
+						"About Audit TDS Bases"
+					)}">?</button>
+				</div>`,
+			},
+			{
 				fieldname: "fiscal_year",
 				fieldtype: "Link",
 				options: "Fiscal Year",
@@ -651,6 +660,29 @@ function open_tds_base_prompt() {
 		},
 	});
 	dialog.show();
+	dialog.fields_dict.tds_help_button.$wrapper
+		.find(".tds-base-help")
+		.on("click", show_tds_base_help);
+}
+
+function show_tds_base_help() {
+	frappe.msgprint({
+		title: __("About Audit TDS Bases"),
+		message: `
+			<p>${__(
+				"Use this tool to check the transaction-currency and company-currency TDS base fields on submitted Purchase Invoices where TDS is enabled and the withholding category calculates TDS on the taxable amount."
+			)}</p>
+			<p><b>${__("Example")}</b></p>
+			<p>${__(
+				"An invoice has a taxable value of {0} and VAT of {1}. If its stored TDS base is incorrectly {2}, the audit suggests changing the TDS base to {0}.",
+				[fmt(1000), fmt(130), fmt(1130)]
+			)}</p>
+			<p>${__(
+				"Applying updates only the two TDS base fields and adds an audit comment. It does not recalculate historical TDS, change VAT rows, or alter General Ledger entries."
+			)}</p>
+		`,
+		indicator: "blue",
+	});
 }
 
 function preview_tds_bases(values) {

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -120,6 +120,9 @@ function show_taxable_summary_help() {
 				"If VAT is charged on a previous tax row (import duty, excise, or similar), taxable value is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%."
 			)}</p>
 			<p>${__(
+				"Paisa-level Taxable or Bill Total differences smaller than 1 are ignored. If Disable Rounded Total is checked, the values already on the invoice are kept; if it is unchecked, rounded total is in use and that rounding error is skipped."
+			)}</p>
+			<p>${__(
 				"If accounting VAT (tax table / GL) disagrees with Taxable × 13%, the invoice is tagged VAT Accounting Error and a comment is added. Applying the summary does not correct GL entries."
 			)}</p>
 		`,

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -227,97 +227,247 @@ function show_preview_dialog(preview, values) {
 	const fy_line = values.fiscal_year
 		? `<li>${__("Fiscal Year")}: <b>${frappe.utils.escape_html(values.fiscal_year)}</b></li>`
 		: "";
-	const more_line = preview.hidden_rows
-		? `<p class="text-muted">${__("…and {0} more invoice(s) not shown in the table. Confirm still updates all of them.", [preview.hidden_rows])}</p>`
-		: "";
 	const batch_line = preview.batched
-		? `<p><b>${__("More than 500 invoices are in this range. Confirm will run in the background in batches of 500.")}</b></p>`
+		? `<p><b>${__("More than 500 invoices were scanned. Large selections will be applied in the background.")}</b></p>`
 		: "";
-
-	let table = "";
-	if (preview.changes && preview.changes.length) {
-		const rows = preview.changes
-			.map((row) => {
-				const name = frappe.utils.escape_html(row.name);
-				const company = frappe.utils.escape_html(row.company || "");
-				const doctype = frappe.utils.escape_html(row.doctype);
-				const invoice_link = frappe.utils.get_form_link(
-					row.doctype,
-					row.name,
-					true,
-					name
-				);
-				return `<tr>
-					<td>${doctype}</td>
-					<td>${invoice_link}</td>
-					<td>${frappe.utils.escape_html(row.posting_date || "")}</td>
-					<td>${company}</td>
-					<td class="text-right">${fmt(row.old_taxable_amount)} → ${fmt(row.new_taxable_amount)}</td>
-					<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
-					<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
-					<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
-				</tr>`;
-			})
-			.join("");
-		table = `<div class="mt-3" style="max-height: 320px; overflow: auto;">
-			<table class="table table-bordered table-sm">
-				<thead>
-					<tr>
-						<th>${__("Type")}</th>
-						<th>${__("Invoice")}</th>
-						<th>${__("Posting Date")}</th>
-						<th>${__("Company")}</th>
-						<th>${__("Taxable")}</th>
-						<th>${__("Non-Taxable")}</th>
-						<th>${__("VAT")}</th>
-						<th>${__("Bill Total")}</th>
-					</tr>
-				</thead>
-				<tbody>${rows}</tbody>
-			</table>
-		</div>${more_line}`;
-	}
+	const suggestions = preview.changes || [];
+	const can_select = (row) => row.would_change;
+	const selectable_count = suggestions.filter(can_select).length;
+	const selected = new Set(
+		suggestions
+			.map((row, index) => (can_select(row) ? index : null))
+			.filter((index) => index !== null)
+	);
+	const page_size = 50;
+	let page = 0;
 
 	const html = `
-		<p>${__("Taxable amount will become the VAT base (VAT ÷ rate). Invoices where VAT is charged on a previous-row total (excise, import duty) will increase. Invoices where VAT is charged on net total stay the same. Purchase invoices with TDS update Bill Total to Grand Total plus TDS (the billed value before withholding).")}</p>
-		<p>${__("Fields that may change: Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and the hidden item VAT detail. IRD Sales/Purchase (and return) registers will use the new taxable column and Bill Total for these invoices. A comment with the new figures is added on each changed invoice.")}</p>
+		<p>${__("When the item flag option is enabled, flagged item totals are Non-Taxable and the remaining item totals are Taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT. Expected VAT is Taxable × 13%, including duty or excise when VAT is charged on a previous tax row. A mismatch is reported, but recorded VAT is retained.")}</p>
+		<p>${__("Applying updates only the selected taxable-summary suggestions. The audit comment records old and new Taxable, Non-Taxable, VAT, and Bill Total values.")}</p>
 		<ul>
 			${fy_line}
 			<li>${__("Posting date range")}: <b>${frappe.utils.escape_html(preview.from_date)}</b> – <b>${frappe.utils.escape_html(preview.to_date)}</b></li>
+			<li>${__("Consider Is Non-Taxable Item")}: <b>${preview.consider_is_non_taxable_item ? __("Yes") : __("No")}</b></li>
 			<li>${__("Scanned")}: <b>${preview.scanned}</b></li>
 			<li>${__("Would change")}: <b>${preview.changed}</b> (${__("Sales")}: ${preview.sales_changed}, ${__("Purchase")}: ${preview.purchase_changed})</li>
+			<li>${__("Calculation warnings")}: <b>${preview.calculation_warnings || 0}</b></li>
 			<li>${__("Unchanged")}: <b>${preview.unchanged}</b></li>
 			<li>${__("Skipped (no VAT account configured)")}: <b>${preview.skipped}</b></li>
 			<li>${__("Denied by permissions")}: <b>${preview.denied || 0}</b></li>
 			<li>${__("Failed")}: <b>${preview.failed || 0}</b></li>
 		</ul>
 		${batch_line}
-		${table}
+		<div class="taxable-summary-selection ${suggestions.length ? "" : "hide"}">
+			<div class="d-flex align-items-center mb-2" style="gap: 8px; flex-wrap: wrap;">
+				<button type="button" class="btn btn-xs btn-default select-all">${__("Select All")}</button>
+				<button type="button" class="btn btn-xs btn-default unselect-all">${__("Unselect All")}</button>
+				<select class="form-control input-xs document-type-filter" style="width: auto;">
+					<option value="Sales Invoice">${__("Sales Invoice")}</option>
+					<option value="Sales Return">${__("Sales Return")}</option>
+					<option value="Purchase Invoice">${__("Purchase Invoice")}</option>
+					<option value="Purchase Return">${__("Purchase Return")}</option>
+				</select>
+				<button type="button" class="btn btn-xs btn-default select-type">${__("Select Type")}</button>
+				<button type="button" class="btn btn-xs btn-default unselect-type">${__("Unselect Type")}</button>
+				<button type="button" class="btn btn-xs btn-default download-csv">${__("Download CSV")}</button>
+				<span class="selected-count text-muted"></span>
+				<span class="pagination-controls ml-auto">
+					<button type="button" class="btn btn-xs btn-default previous-page">${__("Previous")}</button>
+					<span class="page-count mx-2"></span>
+					<button type="button" class="btn btn-xs btn-default next-page">${__("Next")}</button>
+				</span>
+			</div>
+			<div style="max-height: 420px; overflow: auto;">
+				<table class="table table-bordered table-sm">
+					<thead>
+						<tr>
+							<th style="width: 32px;"></th>
+							<th>${__("Type")}</th>
+							<th>${__("Invoice")}</th>
+							<th>${__("Posting Date")}</th>
+							<th>${__("Company")}</th>
+							<th>${__("Taxable")}</th>
+							<th>${__("Non-Taxable")}</th>
+							<th>${__("VAT")}</th>
+							<th>${__("Bill Total")}</th>
+							<th>${__("Calculation Check")}</th>
+						</tr>
+					</thead>
+					<tbody class="suggestion-rows"></tbody>
+				</table>
+			</div>
+		</div>
 	`;
 
 	const dialog = new frappe.ui.Dialog({
 		title: __("Confirm Taxable Summary Refresh"),
 		size: "extra-large",
 		fields: [{ fieldname: "preview_html", fieldtype: "HTML" }],
-		primary_action_label: preview.changed ? __("Apply Changes") : __("Close"),
+		primary_action_label: selectable_count ? __("Apply Changes") : __("Close"),
 		primary_action() {
-			dialog.hide();
-			if (preview.changed) {
-				run_apply(
-					values,
-					preview.changes.map((row) => ({
-						doctype: row.doctype,
-						name: row.name,
-					}))
-				);
+			if (!selectable_count) {
+				dialog.hide();
+				return;
 			}
+			const selected_invoices = [...selected]
+				.filter((index) => can_select(suggestions[index]))
+				.map((index) => ({
+					doctype: suggestions[index].doctype,
+					name: suggestions[index].name,
+				}));
+			if (!selected_invoices.length) {
+				frappe.msgprint(__("Select at least one suggestion to apply."));
+				return;
+			}
+			dialog.hide();
+			run_apply(values, selected_invoices);
 		},
 	});
 	dialog.show();
-	dialog.fields_dict.preview_html.$wrapper.html(html);
-	if (!preview.changed) {
+	const $wrapper = dialog.fields_dict.preview_html.$wrapper;
+	$wrapper.html(html);
+
+	const render_row = (row, extra_check) => {
+		const name = frappe.utils.escape_html(row.name);
+		const invoice_link = frappe.utils.get_form_link(
+			row.doctype,
+			row.name,
+			true,
+			name
+		);
+		const check = row.calculation_check || {};
+		const calculation = check.has_vat_mismatch
+			? `<span class="text-danger">${__(
+					"Expected {0}; recorded {1}; difference {2}",
+					[
+						fmt(check.expected_vat),
+						fmt(check.recorded_vat),
+						fmt(check.vat_difference),
+					]
+				)}</span>`
+			: `<span class="text-success">${__("OK")}</span>`;
+		return `${extra_check}
+			<td>${frappe.utils.escape_html(row.document_type || row.doctype)}</td>
+			<td>${invoice_link}</td>
+			<td>${frappe.utils.escape_html(row.posting_date || "")}</td>
+			<td>${frappe.utils.escape_html(row.company || "")}</td>
+			<td class="text-right">${fmt(row.old_taxable_amount)} → ${fmt(row.new_taxable_amount)}</td>
+			<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
+			<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
+			<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
+			<td>${calculation}${row.would_change ? "" : `<br><small>${__("Review only; no summary change")}</small>`}</td>`;
+	};
+
+	const render_page = () => {
+		const page_count = Math.max(Math.ceil(suggestions.length / page_size), 1);
+		page = Math.min(Math.max(page, 0), page_count - 1);
+		const start = page * page_size;
+		const rows = suggestions.slice(start, start + page_size).map((row, offset) => {
+			const index = start + offset;
+			const disabled = can_select(row) ? "" : "disabled";
+			const checked = selected.has(index) ? "checked" : "";
+			return `<tr>${render_row(
+				row,
+				`<td><input type="checkbox" class="suggestion-select" data-index="${index}" ${checked} ${disabled}></td>`
+			)}</tr>`;
+		});
+		$wrapper.find(".suggestion-rows").html(rows.join(""));
+		$wrapper.find(".selected-count").text(
+			__("{0} of {1} suggestion(s) selected", [selected.size, selectable_count])
+		);
+		$wrapper.find(".download-csv").prop("disabled", !selected.size);
+		$wrapper.find(".page-count").text(
+			__("Page {0} of {1}", [page + 1, page_count])
+		);
+		$wrapper.find(".previous-page").prop("disabled", page === 0);
+		$wrapper.find(".next-page").prop("disabled", page >= page_count - 1);
+		dialog.get_primary_btn().prop("disabled", selectable_count && !selected.size);
+	};
+
+	$wrapper.on("change", ".suggestion-select", function () {
+		const index = Number(this.dataset.index);
+		if (this.checked) {
+			selected.add(index);
+		} else {
+			selected.delete(index);
+		}
+		render_page();
+	});
+	$wrapper.on("click", ".select-all", () => {
+		suggestions.forEach((row, index) => {
+			if (can_select(row)) selected.add(index);
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".unselect-all", () => {
+		selected.clear();
+		render_page();
+	});
+	$wrapper.on("click", ".select-type", () => {
+		const document_type = $wrapper.find(".document-type-filter").val();
+		suggestions.forEach((row, index) => {
+			if (can_select(row) && row.document_type === document_type) {
+				selected.add(index);
+			}
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".unselect-type", () => {
+		const document_type = $wrapper.find(".document-type-filter").val();
+		suggestions.forEach((row, index) => {
+			if (row.document_type === document_type) {
+				selected.delete(index);
+			}
+		});
+		render_page();
+	});
+	$wrapper.on("click", ".download-csv", () => {
+		const selected_rows = [...selected]
+			.sort((a, b) => a - b)
+			.map((index) => suggestions[index])
+			.filter(Boolean);
+		if (!selected_rows.length) {
+			frappe.msgprint(__("Select at least one row to download."));
+			return;
+		}
+		frappe.call({
+			method: "nepal_compliance.taxable_summary.download_taxable_summary_csv",
+			args: {
+				rows: JSON.stringify(selected_rows),
+				from_date: preview.from_date,
+				to_date: preview.to_date,
+			},
+			freeze: true,
+			freeze_message: __("Preparing CSV..."),
+			callback(r) {
+				if (!r.message || !r.message.csv) {
+					return;
+				}
+				const blob = new Blob(["\uFEFF" + r.message.csv], {
+					type: "text/csv;charset=utf-8;",
+				});
+				const link = document.createElement("a");
+				link.href = URL.createObjectURL(blob);
+				link.download = r.message.filename || "taxable_summary.csv";
+				document.body.appendChild(link);
+				link.click();
+				link.remove();
+				URL.revokeObjectURL(link.href);
+			},
+		});
+	});
+	$wrapper.on("click", ".previous-page", () => {
+		page -= 1;
+		render_page();
+	});
+	$wrapper.on("click", ".next-page", () => {
+		page += 1;
+		render_page();
+	});
+	render_page();
+	if (!selectable_count) {
 		dialog.$wrapper.find(".modal-body").prepend(
-			`<div class="alert alert-info">${__("No invoices in this range would change.")}</div>`
+			`<div class="alert alert-info">${__("No invoices in this range would change. Review any calculation warnings below.")}</div>`
 		);
 	}
 }
@@ -347,15 +497,19 @@ function listen_for_refresh_done() {
 		}
 		frappe.msgprint({
 			title: __("Taxable Summary Refresh"),
-			indicator: data.denied || data.failed ? "orange" : "green",
+			indicator:
+				data.denied || data.failed || data.stale || data.calculation_warnings
+					? "orange"
+					: "green",
 			message: __(
-				"Updated {0} invoice(s) from {1} to {2}. Denied: {3}; skipped: {4}; failed: {5}.",
+				"Updated {0} invoice(s) from {1} to {2}. Warnings: {3}; denied: {4}; stale: {5}; failed: {6}.",
 				[
 				data.updated,
 				data.from_date,
 				data.to_date,
+				data.calculation_warnings || 0,
 				data.denied || 0,
-				data.skipped || 0,
+				data.stale || 0,
 				data.failed || 0,
 				]
 			),
@@ -381,8 +535,8 @@ function run_apply(values, selected_invoices) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
-			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			selected_invoices: JSON.stringify(selected_invoices),
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,
@@ -405,17 +559,18 @@ function run_apply(values, selected_invoices) {
 				}
 				frappe.msgprint(
 					__(
-						"More than 500 invoices are in this range. The update is running in the background in batches of 500. You will be notified when it finishes."
+						"More than 500 invoices were selected. The update is running in the background in batches of 500. You will be notified when it finishes."
 					)
 				);
 				return;
 			}
 			delete frappe._taxable_summary_apply_pending[request_id];
 			frappe.msgprint(
-				__("Updated {0} invoice(s). Denied: {1}; skipped: {2}; failed: {3}.", [
+				__("Updated {0} invoice(s). Warnings: {1}; denied: {2}; stale: {3}; failed: {4}.", [
 					r.message.updated,
+					r.message.calculation_warnings || 0,
 					r.message.denied || 0,
-					r.message.skipped || 0,
+					r.message.stale || 0,
 					r.message.failed || 0,
 				])
 			);

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -21,6 +21,15 @@ function open_date_prompt() {
 		title: __("Recompute Taxable Summary"),
 		fields: [
 			{
+				fieldname: "recompute_help_button",
+				fieldtype: "HTML",
+				options: `<div class="text-right">
+					<button type="button" class="btn btn-xs btn-default recompute-help" title="${__(
+						"About Recompute Taxable Summary"
+					)}">?</button>
+				</div>`,
+			},
+			{
 				fieldname: "fiscal_year",
 				fieldtype: "Link",
 				options: "Fiscal Year",
@@ -56,11 +65,20 @@ function open_date_prompt() {
 				reqd: 1,
 			},
 			{
+				fieldname: "consider_is_non_taxable_item",
+				fieldtype: "Check",
+				label: __("Consider Is Non-Taxable Item"),
+				default: 0,
+				description: __(
+					"Classify flagged item rows as non-taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT."
+				),
+			},
+			{
 				fieldname: "help",
 				fieldtype: "HTML",
 				options: `<p class="text-muted">
 					${__(
-						"Select a Fiscal Year to fill the dates, or enter a posting date range. Only submitted Sales and Purchase Invoices in this range will be scanned."
+						"Only submitted Sales and Purchase Invoices in this range will be scanned. VAT calculation mismatches are warnings; VAT recorded in invoice tax rows is retained."
 					)}
 				</p>`,
 			},
@@ -76,6 +94,34 @@ function open_date_prompt() {
 		},
 	});
 	dialog.show();
+	dialog.fields_dict.recompute_help_button.$wrapper
+		.find(".recompute-help")
+		.on("click", show_taxable_summary_help);
+}
+
+function show_taxable_summary_help() {
+	frappe.msgprint({
+		title: __("About Recompute Taxable Summary"),
+		message: `
+			<p>${__(
+				"Use this tool to preview and correct the Taxable Amount, Non-Taxable Amount, VAT Amount, Bill Total, and item VAT summary stored on submitted Sales and Purchase Invoices. You can select which suggestions to apply."
+			)}</p>
+			<p><b>${__("Example")}</b></p>
+			<ul>
+				<li>${__("Taxable item total")}: ${fmt(4189.33)}</li>
+				<li>${__("Non-taxable item total")}: ${fmt(28029)}</li>
+				<li>${__("Expected VAT")}: ${fmt(4189.33)} × 13% = ${fmt(544.61)}</li>
+				<li>${__("Bill Total")}: ${fmt(32218.33)} + ${fmt(544.61)} = ${fmt(32762.94)}</li>
+			</ul>
+			<p>${__(
+				"If Is PAN/Abbreviated Bill is checked, a Purchase Invoice has no Taxes and Charges rows, or its recorded VAT is zero, all its items are treated as non-taxable and expected VAT is zero."
+			)}</p>
+			<p>${__(
+				"If VAT is charged on a previous tax row (import duty, excise, or similar), taxable value is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%."
+			)}</p>
+		`,
+		indicator: "blue",
+	});
 }
 
 function listen_for_preview_done() {
@@ -124,6 +170,7 @@ function run_preview(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,
@@ -328,6 +375,7 @@ function run_apply(values) {
 		args: {
 			from_date: values.from_date,
 			to_date: values.to_date,
+			consider_is_non_taxable_item: values.consider_is_non_taxable_item || 0,
 			request_id: request_id,
 		},
 		freeze: true,

--- a/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
+++ b/nepal_compliance/nepal_compliance/doctype/nepal_compliance_settings/nepal_compliance_settings.js
@@ -119,6 +119,9 @@ function show_taxable_summary_help() {
 			<p>${__(
 				"If VAT is charged on a previous tax row (import duty, excise, or similar), taxable value is the VAT base (item net plus those added taxes), then expected VAT is that base × 13%."
 			)}</p>
+			<p>${__(
+				"If accounting VAT (tax table / GL) disagrees with Taxable × 13%, the invoice is tagged VAT Accounting Error and a comment is added. Applying the summary does not correct GL entries."
+			)}</p>
 		`,
 		indicator: "blue",
 	});
@@ -231,7 +234,9 @@ function show_preview_dialog(preview, values) {
 		? `<p><b>${__("More than 500 invoices were scanned. Large selections will be applied in the background.")}</b></p>`
 		: "";
 	const suggestions = preview.changes || [];
-	const can_select = (row) => row.would_change;
+	const has_vat_error = (row) =>
+		Boolean(row.calculation_check && row.calculation_check.has_vat_mismatch);
+	const can_select = (row) => row.would_change || has_vat_error(row);
 	const selectable_count = suggestions.filter(can_select).length;
 	const selected = new Set(
 		suggestions
@@ -242,8 +247,8 @@ function show_preview_dialog(preview, values) {
 	let page = 0;
 
 	const html = `
-		<p>${__("When the item flag option is enabled, flagged item totals are Non-Taxable and the remaining item totals are Taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT. Expected VAT is Taxable × 13%, including duty or excise when VAT is charged on a previous tax row. A mismatch is reported, but recorded VAT is retained.")}</p>
-		<p>${__("Applying updates only the selected taxable-summary suggestions. The audit comment records old and new Taxable, Non-Taxable, VAT, and Bill Total values.")}</p>
+		<p>${__("When the item flag option is enabled, flagged item totals are Non-Taxable and the remaining item totals are Taxable. A Purchase Invoice is fully non-taxable when it is a PAN/Abbreviated Bill, has no tax rows, or has zero recorded VAT. Expected VAT is Taxable × 13%, including duty or excise when VAT is charged on a previous tax row. If accounting VAT disagrees, the invoice is tagged VAT Accounting Error; recorded VAT is retained because GL is not rewritten.")}</p>
+		<p>${__("Applying updates the selected taxable-summary suggestions. Invoices with a VAT accounting error are tagged and commented even when summary fields do not change.")}</p>
 		<ul>
 			${fy_line}
 			<li>${__("Posting date range")}: <b>${frappe.utils.escape_html(preview.from_date)}</b> – <b>${frappe.utils.escape_html(preview.to_date)}</b></li>
@@ -337,15 +342,22 @@ function show_preview_dialog(preview, values) {
 		);
 		const check = row.calculation_check || {};
 		const calculation = check.has_vat_mismatch
-			? `<span class="text-danger">${__(
-					"Expected {0}; recorded {1}; difference {2}",
+			? `<span class="indicator-pill red filterable no-indicator-dot">${__(
+					"Error"
+				)}</span><br><small class="text-danger">${__(
+					"Expected {0}; accounting {1}; difference {2}",
 					[
 						fmt(check.expected_vat),
 						fmt(check.recorded_vat),
 						fmt(check.vat_difference),
 					]
-				)}</span>`
+				)}</small>`
 			: `<span class="text-success">${__("OK")}</span>`;
+		const note = row.would_change
+			? ""
+			: `<br><small>${__(
+					"IRD summary unchanged; tag accounting VAT error"
+				)}</small>`;
 		return `${extra_check}
 			<td>${frappe.utils.escape_html(row.document_type || row.doctype)}</td>
 			<td>${invoice_link}</td>
@@ -355,7 +367,7 @@ function show_preview_dialog(preview, values) {
 			<td class="text-right">${fmt(row.old_non_taxable_amount)} → ${fmt(row.new_non_taxable_amount)}</td>
 			<td class="text-right">${fmt(row.old_vat_amount)} → ${fmt(row.new_vat_amount)}</td>
 			<td class="text-right">${fmt(row.old_summary_grand_total)} → ${fmt(row.new_summary_grand_total)}</td>
-			<td>${calculation}${row.would_change ? "" : `<br><small>${__("Review only; no summary change")}</small>`}</td>`;
+			<td>${calculation}${note}</td>`;
 	};
 
 	const render_page = () => {
@@ -469,6 +481,10 @@ function show_preview_dialog(preview, values) {
 		dialog.$wrapper.find(".modal-body").prepend(
 			`<div class="alert alert-info">${__("No invoices in this range would change. Review any calculation warnings below.")}</div>`
 		);
+	} else if (!preview.changed) {
+		dialog.$wrapper.find(".modal-body").prepend(
+			`<div class="alert alert-danger">${__("Accounting VAT disagrees with Taxable × 13% on some invoices. Apply to tag them VAT Accounting Error. GL is not rewritten.")}</div>`
+		);
 	}
 }
 
@@ -502,7 +518,7 @@ function listen_for_refresh_done() {
 					? "orange"
 					: "green",
 			message: __(
-				"Updated {0} invoice(s) from {1} to {2}. Warnings: {3}; denied: {4}; stale: {5}; failed: {6}.",
+				"Updated {0} invoice(s) from {1} to {2}. VAT accounting errors tagged: {3}; denied: {4}; stale: {5}; failed: {6}.",
 				[
 				data.updated,
 				data.from_date,
@@ -566,7 +582,7 @@ function run_apply(values, selected_invoices) {
 			}
 			delete frappe._taxable_summary_apply_pending[request_id];
 			frappe.msgprint(
-				__("Updated {0} invoice(s). Warnings: {1}; denied: {2}; stale: {3}; failed: {4}.", [
+				__("Updated {0} invoice(s). VAT accounting errors tagged: {1}; denied: {2}; stale: {3}; failed: {4}.", [
 					r.message.updated,
 					r.message.calculation_warnings || 0,
 					r.message.denied || 0,

--- a/nepal_compliance/nepali_date_utils/bs_periods.py
+++ b/nepal_compliance/nepali_date_utils/bs_periods.py
@@ -23,16 +23,26 @@ def end_of(y, m):
     return bs_to_ad(y, m, days_in_bs_month(y, m))
 
 
+def is_fiscal_period_month(y, m, freq):
+    """Return whether a BS month closes a continuous Ashadh-anchored period."""
+    freq = max(cint(freq), 1)
+    month_index = y * 12 + (m - 1)
+    ashadh_index = 2
+    return (month_index - ashadh_index) % freq == 0
+
+
 def next_fiscal_period_end(y, m, freq):
     """First BS month on or after (y, m) that ends a Nepali fiscal period.
 
     The Nepali fiscal year runs 1 Shrawan to end of Ashadh (months 4..3), so a
-    month closes a fiscal period exactly when (m - 3) % freq == 0:
+    continuous month offset from Ashadh determines each period end:
     monthly (1) -> every month; quarterly (3) -> Ashwin/Poush/Chaitra/Ashadh;
     half-yearly (6) -> Poush/Ashadh; yearly (12) -> Ashadh (FY end).
+    Including the BS year keeps arbitrary ERPNext frequencies consistent when
+    a period crosses a year boundary.
     """
     freq = max(cint(freq), 1)
-    while (m - 3) % freq != 0:
+    while not is_fiscal_period_month(y, m, freq):
         y, m = advance(y, m, 1)
     return y, m
 

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -1,12 +1,11 @@
 import frappe
 from frappe import _
-from frappe.utils import flt, getdate
+from frappe.utils import cint, flt, getdate
 from frappe.utils.background_jobs import enqueue
 
 from nepal_compliance.utils import set_taxable_amounts
 
 BATCH_SIZE = 500
-PREVIEW_TABLE_LIMIT = 100
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
 
 
@@ -49,6 +48,7 @@ def _iter_invoice_rows(from_date, to_date):
         "name",
         "company",
         "posting_date",
+        "is_return",
         "taxable_amount",
         "non_taxable_amount",
         "vat_amount",
@@ -74,6 +74,14 @@ def _iter_invoice_rows(from_date, to_date):
             start += BATCH_SIZE
 
 
+SUMMARY_COMPARE_FIELDS = (
+    "taxable_amount",
+    "non_taxable_amount",
+    "vat_amount",
+    "summary_grand_total",
+)
+
+
 def _amt(value):
     """Round a money field to 2 decimals, preserving None."""
     return None if value is None else flt(value, 2)
@@ -81,29 +89,49 @@ def _amt(value):
 
 def _figures_changed(old, new):
     """True when taxable, non-taxable, VAT, or Bill Total would change."""
-    return (
-        _amt(old.taxable_amount) != _amt(new.taxable_amount)
-        or _amt(old.non_taxable_amount) != _amt(new.non_taxable_amount)
-        or _amt(old.vat_amount) != _amt(new.vat_amount)
-        or _amt(old.summary_grand_total) != _amt(new.summary_grand_total)
+    return any(
+        _amt(old.get(field)) != _amt(new.get(field))
+        for field in SUMMARY_COMPARE_FIELDS
     )
 
 
-def _compute_refresh_row(doctype, row):
+def _document_type(doctype, is_return):
+    if not is_return:
+        return doctype
+    return "Sales Return" if doctype == "Sales Invoice" else "Purchase Return"
+
+
+def _compute_refresh_row(doctype, row, consider_is_non_taxable_item=False):
     """Recompute one invoice's taxable summary and classify the result."""
     doc = frappe.get_doc(doctype, row.name)
-    set_taxable_amounts(doc, None)
+    if not frappe.has_permission(doctype, "write", doc=doc):
+        return "denied", None
+
+    calculation_check = set_taxable_amounts(
+        doc,
+        None,
+        consider_is_non_taxable_item=consider_is_non_taxable_item,
+    )
     if doc.get("taxable_amount") is None:
         return "skipped", None
 
-    if not _figures_changed(row, doc):
+    figures_changed = _figures_changed(row, doc)
+    has_warning = bool(
+        calculation_check and calculation_check.get("has_vat_mismatch")
+    )
+    if not figures_changed and not has_warning:
         return "unchanged", None
 
-    return "changed", {
+    return ("changed" if figures_changed else "warning"), {
         "doctype": doctype,
+        "document_type": _document_type(doctype, row.get("is_return")),
         "name": row.name,
         "company": row.company,
         "posting_date": str(row.posting_date),
+        "would_change": figures_changed,
+        "vat_on_added_taxes": bool(
+            calculation_check and calculation_check.get("vat_on_added_taxes")
+        ),
         "old_taxable_amount": _amt(row.taxable_amount),
         "new_taxable_amount": _amt(doc.taxable_amount),
         "old_non_taxable_amount": _amt(row.non_taxable_amount),
@@ -113,31 +141,48 @@ def _compute_refresh_row(doctype, row):
         "old_summary_grand_total": _amt(row.summary_grand_total),
         "new_summary_grand_total": _amt(doc.summary_grand_total),
         "summary_grand_total": doc.summary_grand_total,
-        "item_vat_detail": doc.item_vat_detail,
+        "item_vat_detail": doc.get("item_vat_detail"),
+        "calculation_check": calculation_check,
     }
 
 
-def _scan_changes(from_date, to_date):
+def _scan_changes(from_date, to_date, consider_is_non_taxable_item=False):
     """Scan invoices in range and return preview rows plus counts."""
     scanned = 0
     unchanged = 0
     skipped = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
     by_doctype = {doctype: 0 for doctype in DOCTYPE_ORDER}
     changes = []
 
     for doctype, row in _iter_invoice_rows(from_date, to_date):
         scanned += 1
-        status, change = _compute_refresh_row(doctype, row)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Preview Failed for {0}").format(row.name)
+            )
+            continue
         if status == "skipped":
             skipped += 1
+        elif status == "denied":
+            denied += 1
         elif status == "unchanged":
             unchanged += 1
         else:
-            by_doctype[doctype] += 1
-            if len(changes) < PREVIEW_TABLE_LIMIT:
-                changes.append(
-                    {k: change[k] for k in change if k != "item_vat_detail"}
-                )
+            if change["calculation_check"] and change["calculation_check"].get(
+                "has_vat_mismatch"
+            ):
+                calculation_warnings += 1
+            if status == "changed":
+                by_doctype[doctype] += 1
+            changes.append({k: change[k] for k in change if k != "item_vat_detail"})
 
     changed = sum(by_doctype.values())
     return {
@@ -148,11 +193,14 @@ def _scan_changes(from_date, to_date):
         "changed": changed,
         "unchanged": unchanged,
         "skipped": skipped,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
         "sales_changed": by_doctype["Sales Invoice"],
         "purchase_changed": by_doctype["Purchase Invoice"],
         "batched": scanned > BATCH_SIZE,
         "changes": changes,
-        "hidden_rows": max(changed - len(changes), 0),
+        "consider_is_non_taxable_item": bool(consider_is_non_taxable_item),
     }
 
 
@@ -174,25 +222,87 @@ def _apply_change(change):
     doc.add_comment(
         "Comment",
         _(
-            "Nepal Compliance: taxable summary recomputed from VAT base "
-            "(VAT ÷ rate). Taxable: {0}, Non-Taxable: {1}, VAT: {2}, Bill Total: {3}"
+            "Nepal Compliance: taxable summary recomputed. "
+            "Taxable: {0} → {1}, Non-Taxable: {2} → {3}, "
+            "VAT: {4} → {5}, Bill Total: {6} → {7}."
         ).format(
+            flt(change["old_taxable_amount"], 2),
             flt(change["new_taxable_amount"], 2),
+            flt(change["old_non_taxable_amount"], 2),
             flt(change["new_non_taxable_amount"], 2),
+            flt(change["old_vat_amount"], 2),
             flt(change["new_vat_amount"], 2),
+            flt(change["old_summary_grand_total"], 2),
             flt(change["new_summary_grand_total"], 2),
         ),
     )
 
 
-def _run_apply(from_date, to_date):
-    """Apply recomputed taxable summary values, committing every BATCH_SIZE invoices."""
+def _parse_selected_invoices(selected_invoices):
+    """Return validated selected invoice keys from a JSON/list payload."""
+    selected = (
+        frappe.parse_json(selected_invoices)
+        if isinstance(selected_invoices, str)
+        else selected_invoices
+    )
+    if not isinstance(selected, list):
+        frappe.throw(_("Selected invoices must be a list."))
+
+    keys = set()
+    for row in selected:
+        if not isinstance(row, dict):
+            frappe.throw(_("Each selected invoice must include a type and name."))
+        doctype = row.get("doctype")
+        name = row.get("name")
+        if doctype not in DOCTYPE_ORDER or not name:
+            frappe.throw(_("Invalid selected invoice: {0} {1}").format(doctype, name))
+        keys.add((doctype, name))
+    return keys
+
+
+def _run_apply(
+    from_date,
+    to_date,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+):
+    """Apply selected recomputed values, committing every BATCH_SIZE invoices."""
+    selected = (
+        set(selected_invoices)
+        if isinstance(selected_invoices, set)
+        else _parse_selected_invoices(selected_invoices)
+    )
     updated = 0
+    denied = 0
+    failed = 0
+    calculation_warnings = 0
+    stale = 0
     batch_count = 0
     for doctype, row in _iter_invoice_rows(from_date, to_date):
-        status, change = _compute_refresh_row(doctype, row)
-        if status != "changed":
+        key = (doctype, row.name)
+        if key not in selected:
             continue
+        selected.remove(key)
+        try:
+            status, change = _compute_refresh_row(
+                doctype, row, consider_is_non_taxable_item
+            )
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                title=_("Taxable Summary Apply Failed for {0}").format(row.name)
+            )
+            continue
+        if status == "denied":
+            denied += 1
+            continue
+        if status != "changed":
+            stale += 1
+            continue
+        if change["calculation_check"] and change["calculation_check"].get(
+            "has_vat_mismatch"
+        ):
+            calculation_warnings += 1
         _apply_change(change)
         updated += 1
         batch_count += 1
@@ -202,11 +312,23 @@ def _run_apply(from_date, to_date):
     if batch_count:
         frappe.db.commit()  # nosemgrep
 
-    return updated
+    stale += len(selected)
+    return {
+        "updated": updated,
+        "denied": denied,
+        "failed": failed,
+        "calculation_warnings": calculation_warnings,
+        "stale": stale,
+    }
 
 
-@frappe.whitelist()
-def preview_taxable_summary_refresh(from_date: str, to_date: str):
+@frappe.whitelist(methods=["POST"])
+def preview_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Preview invoices whose taxable summary would change in the date range.
 
     Ranges larger than BATCH_SIZE run on the long queue so the HTTP worker
@@ -214,8 +336,10 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
     """
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
     scanned = _count_invoices(from_date, to_date)
     if scanned > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_preview",
             queue="long",
@@ -223,28 +347,48 @@ def preview_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
         return {
             "queued": True,
-            "updated": 0,
             "scanned": scanned,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         }
-    return _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, consider_is_non_taxable_item
+    )
+    preview["request_id"] = request_id
+    return preview
 
 
-@frappe.whitelist()
-def apply_taxable_summary_refresh(from_date: str, to_date: str):
+@frappe.whitelist(methods=["POST"])
+def apply_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices: list | str | None = None,
+    consider_is_non_taxable_item: int | bool = 0,
+    request_id: str | None = None,
+):
     """Apply recomputed taxable summary values, enqueueing ranges above BATCH_SIZE."""
     _ensure_permission()
     from_date, to_date = _resolve_dates(from_date, to_date)
-    scanned = _count_invoices(from_date, to_date)
-    if not scanned:
-        return {"queued": False, "updated": 0, "scanned": 0}
+    selected = _parse_selected_invoices(selected_invoices or [])
+    consider_is_non_taxable_item = bool(cint(consider_is_non_taxable_item))
+    if not selected:
+        return {
+            "queued": False,
+            "updated": 0,
+            "scanned": 0,
+            "request_id": request_id,
+        }
 
-    if scanned > BATCH_SIZE:
+    if len(selected) > BATCH_SIZE:
+        user = frappe.session.user
         enqueue(
             method="nepal_compliance.taxable_summary.run_taxable_summary_refresh",
             queue="long",
@@ -252,37 +396,81 @@ def apply_taxable_summary_refresh(from_date: str, to_date: str):
             is_async=True,
             from_date=str(from_date),
             to_date=str(to_date),
+            selected_invoices=[
+                {"doctype": doctype, "name": name}
+                for doctype, name in sorted(selected)
+            ],
+            consider_is_non_taxable_item=consider_is_non_taxable_item,
+            request_id=request_id,
+            user=user,
             enqueue_after_commit=True,
         )
-        return {"queued": True, "updated": 0, "scanned": scanned}
+        return {
+            "queued": True,
+            "updated": 0,
+            "scanned": len(selected),
+            "request_id": request_id,
+        }
 
-    updated = _run_apply(from_date, to_date)
-    return {"queued": False, "updated": updated, "scanned": scanned}
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected,
+        consider_is_non_taxable_item,
+    )
+    return {
+        "queued": False,
+        "scanned": len(selected),
+        "request_id": request_id,
+        **result,
+    }
 
 
-def run_taxable_summary_preview(from_date: str, to_date: str):
+def run_taxable_summary_preview(
+    from_date: str,
+    to_date: str,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background preview scan; publishes taxable_summary_preview_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    preview = _scan_changes(from_date, to_date)
+    preview = _scan_changes(
+        from_date, to_date, bool(consider_is_non_taxable_item)
+    )
+    preview["request_id"] = request_id
     frappe.publish_realtime(
         "taxable_summary_preview_done",
         preview,
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
     return preview
 
 
-def run_taxable_summary_refresh(from_date: str, to_date: str):
+def run_taxable_summary_refresh(
+    from_date: str,
+    to_date: str,
+    selected_invoices,
+    consider_is_non_taxable_item=False,
+    request_id=None,
+    user=None,
+):
     """Background apply; publishes taxable_summary_refresh_done when finished."""
     from_date, to_date = _resolve_dates(from_date, to_date)
-    updated = _run_apply(from_date, to_date)
+    result = _run_apply(
+        from_date,
+        to_date,
+        selected_invoices,
+        bool(consider_is_non_taxable_item),
+    )
     frappe.publish_realtime(
         "taxable_summary_refresh_done",
         {
-            "updated": updated,
+            **result,
             "from_date": str(from_date),
             "to_date": str(to_date),
+            "request_id": request_id,
         },
-        user=frappe.session.user,
+        user=user or frappe.session.user,
     )
-    return updated
+    return result

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -2,11 +2,32 @@ import frappe
 from frappe import _
 from frappe.utils import cint, flt, getdate
 from frappe.utils.background_jobs import enqueue
+from frappe.utils.csvutils import to_csv
 
 from nepal_compliance.utils import set_taxable_amounts
 
 BATCH_SIZE = 500
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
+TAXABLE_SUMMARY_CSV_COLUMNS = [
+    "Type",
+    "Invoice",
+    "Posting Date",
+    "Company",
+    "Taxable (Old)",
+    "Taxable (New)",
+    "Non-Taxable (Old)",
+    "Non-Taxable (New)",
+    "VAT (Old)",
+    "VAT (New)",
+    "Bill Total (Old)",
+    "Bill Total (New)",
+    "Would Change",
+    "Group",
+    "Expected VAT",
+    "Recorded VAT",
+    "Difference",
+    "Calculation Check",
+]
 
 
 def _ensure_permission():
@@ -319,6 +340,64 @@ def _run_apply(
         "failed": failed,
         "calculation_warnings": calculation_warnings,
         "stale": stale,
+    }
+
+
+def _csv_amount(value):
+    """Format a money field for CSV, leaving blanks when unset."""
+    return "" if value is None else flt(value, 2)
+
+
+def taxable_summary_csv_data(changes):
+    """Return CSV header plus one row per taxable-summary preview change."""
+    data = [TAXABLE_SUMMARY_CSV_COLUMNS]
+    for change in changes or []:
+        check = change.get("calculation_check") or {}
+        data.append(
+            [
+                change.get("document_type") or change.get("doctype") or "",
+                change.get("name") or "",
+                change.get("posting_date") or "",
+                change.get("company") or "",
+                _csv_amount(change.get("old_taxable_amount")),
+                _csv_amount(change.get("new_taxable_amount")),
+                _csv_amount(change.get("old_non_taxable_amount")),
+                _csv_amount(change.get("new_non_taxable_amount")),
+                _csv_amount(change.get("old_vat_amount")),
+                _csv_amount(change.get("new_vat_amount")),
+                _csv_amount(change.get("old_summary_grand_total")),
+                _csv_amount(change.get("new_summary_grand_total")),
+                _("Yes") if change.get("would_change") else _("No"),
+                _("Includes added taxes")
+                if change.get("vat_on_added_taxes")
+                else _("Suggestion"),
+                _csv_amount(check.get("expected_vat")),
+                _csv_amount(check.get("recorded_vat")),
+                _csv_amount(check.get("vat_difference")),
+                _("Mismatch") if check.get("has_vat_mismatch") else _("OK"),
+            ]
+        )
+    return data
+
+
+@frappe.whitelist(methods=["POST"])
+def download_taxable_summary_csv(
+    rows: list | str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+):
+    """Return a CSV file for the selected taxable-summary preview rows."""
+    _ensure_permission()
+    changes = frappe.parse_json(rows) if isinstance(rows, str) else rows
+    if not isinstance(changes, list) or not changes:
+        frappe.throw(_("Select at least one row to download."))
+
+    filename = "taxable_summary"
+    if from_date and to_date:
+        filename = f"taxable_summary_{from_date}_to_{to_date}"
+    return {
+        "filename": f"{filename}.csv",
+        "csv": to_csv(taxable_summary_csv_data(changes)),
     }
 
 

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -75,6 +75,7 @@ def _iter_invoice_rows(from_date, to_date):
         "non_taxable_amount",
         "vat_amount",
         "summary_grand_total",
+        "disable_rounded_total",
     ]
     for doctype in DOCTYPE_ORDER:
         start = 0
@@ -102,6 +103,7 @@ SUMMARY_COMPARE_FIELDS = (
     "vat_amount",
     "summary_grand_total",
 )
+ROUNDING_IGNORE_LIMIT = 1.0
 
 
 def _amt(value):
@@ -109,12 +111,26 @@ def _amt(value):
     return None if value is None else flt(value, 2)
 
 
-def _figures_changed(old, new):
-    """True when taxable, non-taxable, VAT, or Bill Total would change."""
-    return any(
+def _abs_diff(old_value, new_value):
+    """Absolute difference between money fields, treating None as zero."""
+    return abs(flt(old_value) - flt(new_value))
+
+
+def _figures_changed(old, new, disable_rounded_total=False):
+    """Ignore sub-rupee summary noise for either rounded-total setting."""
+    changed = any(
         _amt(old.get(field)) != _amt(new.get(field))
         for field in SUMMARY_COMPARE_FIELDS
     )
+    if not changed:
+        return False
+    minor = all(
+        _abs_diff(old.get(field), new.get(field)) < ROUNDING_IGNORE_LIMIT
+        for field in SUMMARY_COMPARE_FIELDS
+    )
+    if minor:
+        return False
+    return True
 
 
 def _document_type(doctype, is_return):
@@ -137,7 +153,11 @@ def _compute_refresh_row(doctype, row, consider_is_non_taxable_item=False):
     if doc.get("taxable_amount") is None:
         return "skipped", None
 
-    figures_changed = _figures_changed(row, doc)
+    figures_changed = _figures_changed(
+        row,
+        doc,
+        disable_rounded_total=cint(doc.get("disable_rounded_total")),
+    )
     has_warning = bool(
         calculation_check and calculation_check.get("has_vat_mismatch")
     )

--- a/nepal_compliance/taxable_summary.py
+++ b/nepal_compliance/taxable_summary.py
@@ -8,6 +8,7 @@ from nepal_compliance.utils import set_taxable_amounts
 
 BATCH_SIZE = 500
 DOCTYPE_ORDER = ("Sales Invoice", "Purchase Invoice")
+VAT_ACCOUNTING_ERROR_TAG = "VAT Accounting Error"
 TAXABLE_SUMMARY_CSV_COLUMNS = [
     "Type",
     "Invoice",
@@ -225,6 +226,36 @@ def _scan_changes(from_date, to_date, consider_is_non_taxable_item=False):
     }
 
 
+def _has_vat_accounting_error(calculation_check):
+    """True when tax-table VAT disagrees with Taxable × 13%."""
+    return bool(calculation_check and calculation_check.get("has_vat_mismatch"))
+
+
+def _flag_vat_accounting_error(doc, calculation_check):
+    """Tag and comment an invoice whose accounting VAT is wrong."""
+    if not _has_vat_accounting_error(calculation_check):
+        return
+    doc.add_tag(VAT_ACCOUNTING_ERROR_TAG)
+    doc.add_comment(
+        "Comment",
+        _(
+            "Nepal Compliance: VAT Accounting Error. Expected VAT {0} "
+            "(Taxable × 13%) but accounting has {1} (difference {2}). "
+            "IRD summary can be correct while GL / tax-table VAT stays wrong."
+        ).format(
+            flt(calculation_check["expected_vat"], 2),
+            flt(calculation_check["recorded_vat"], 2),
+            flt(calculation_check["vat_difference"], 2),
+        ),
+    )
+
+
+def _flag_invoice(change):
+    """Flag a VAT accounting error without rewriting summary fields."""
+    doc = frappe.get_doc(change["doctype"], change["name"])
+    _flag_vat_accounting_error(doc, change.get("calculation_check") or {})
+
+
 def _apply_change(change):
     """Write recomputed taxable summary fields and add a comment on the invoice."""
     frappe.db.set_value(
@@ -257,6 +288,7 @@ def _apply_change(change):
             flt(change["new_summary_grand_total"], 2),
         ),
     )
+    _flag_vat_accounting_error(doc, change.get("calculation_check") or {})
 
 
 def _parse_selected_invoices(selected_invoices):
@@ -317,14 +349,15 @@ def _run_apply(
         if status == "denied":
             denied += 1
             continue
-        if status != "changed":
+        if status not in ("changed", "warning"):
             stale += 1
             continue
-        if change["calculation_check"] and change["calculation_check"].get(
-            "has_vat_mismatch"
-        ):
+        if _has_vat_accounting_error(change.get("calculation_check")):
             calculation_warnings += 1
-        _apply_change(change)
+        if status == "changed":
+            _apply_change(change)
+        else:
+            _flag_invoice(change)
         updated += 1
         batch_count += 1
         if batch_count >= BATCH_SIZE:
@@ -368,13 +401,17 @@ def taxable_summary_csv_data(changes):
                 _csv_amount(change.get("old_summary_grand_total")),
                 _csv_amount(change.get("new_summary_grand_total")),
                 _("Yes") if change.get("would_change") else _("No"),
-                _("Includes added taxes")
-                if change.get("vat_on_added_taxes")
-                else _("Suggestion"),
+                _("VAT Accounting Error")
+                if _has_vat_accounting_error(check)
+                else (
+                    _("Includes added taxes")
+                    if change.get("vat_on_added_taxes")
+                    else _("Suggestion")
+                ),
                 _csv_amount(check.get("expected_vat")),
                 _csv_amount(check.get("recorded_vat")),
                 _csv_amount(check.get("vat_difference")),
-                _("Mismatch") if check.get("has_vat_mismatch") else _("OK"),
+                _("Error") if check.get("has_vat_mismatch") else _("OK"),
             ]
         )
     return data

--- a/nepal_compliance/test/test_bs_periods.py
+++ b/nepal_compliance/test/test_bs_periods.py
@@ -1,0 +1,27 @@
+import unittest
+
+from nepal_compliance.nepali_date_utils.bs_periods import (
+    is_fiscal_period_month,
+    next_fiscal_period_end,
+)
+from nepal_compliance.overrides.asset_depreciation_schedule import (
+    is_bs_fiscal_period_end,
+)
+
+
+class TestBSFiscalPeriods(unittest.TestCase):
+    def test_standard_fiscal_period_end_months(self):
+        self.assertTrue(is_fiscal_period_month(2083, 3, 12))
+        self.assertTrue(is_fiscal_period_month(2083, 6, 3))
+        self.assertFalse(is_fiscal_period_month(2083, 5, 3))
+
+    def test_next_period_end_uses_same_anchor(self):
+        self.assertEqual(next_fiscal_period_end(2083, 4, 3), (2083, 6))
+        self.assertEqual(next_fiscal_period_end(2083, 12, 6), (2084, 3))
+
+    def test_asset_override_imports_period_helper(self):
+        self.assertTrue(callable(is_bs_fiscal_period_end))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -247,6 +247,60 @@ class TestSelectableTaxableSummary(unittest.TestCase):
         self.assertEqual(result["updated"], 1)
         self.assertEqual(result["calculation_warnings"], 1)
 
+    def test_paisa_taxable_difference_is_ignored(self):
+        old = frappe._dict(
+            taxable_amount=681.41,
+            non_taxable_amount=0,
+            vat_amount=88.58,
+            summary_grand_total=770,
+        )
+        new = frappe._dict(
+            taxable_amount=681.42,
+            non_taxable_amount=0,
+            vat_amount=88.58,
+            summary_grand_total=770,
+        )
+
+        self.assertFalse(
+            taxable_summary._figures_changed(old, new, disable_rounded_total=1)
+        )
+
+    def test_sub_rupee_bill_total_difference_is_ignored(self):
+        old = frappe._dict(
+            taxable_amount=35690,
+            non_taxable_amount=0,
+            vat_amount=4639.7,
+            summary_grand_total=40330,
+        )
+        new = frappe._dict(
+            taxable_amount=35690,
+            non_taxable_amount=0,
+            vat_amount=4639.7,
+            summary_grand_total=40329.7,
+        )
+
+        self.assertFalse(
+            taxable_summary._figures_changed(old, new, disable_rounded_total=0)
+        )
+
+    def test_real_taxable_change_is_not_ignored(self):
+        old = frappe._dict(
+            taxable_amount=4849.5,
+            non_taxable_amount=0,
+            vat_amount=661.96,
+            summary_grand_total=5753.93,
+        )
+        new = frappe._dict(
+            taxable_amount=5091.98,
+            non_taxable_amount=0,
+            vat_amount=661.96,
+            summary_grand_total=5753.93,
+        )
+
+        self.assertTrue(
+            taxable_summary._figures_changed(old, new, disable_rounded_total=0)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import frappe
 
-from nepal_compliance import utils
+from nepal_compliance import taxable_summary, utils
 
 
 class TestTaxableSummaryCalculation(unittest.TestCase):
@@ -109,6 +109,82 @@ class TestTaxableSummaryCalculation(unittest.TestCase):
         )
 
         self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+
+class TestSelectableTaxableSummary(unittest.TestCase):
+    def test_refresh_endpoints_are_post_only(self):
+        allowed = frappe.allowed_http_methods_for_whitelisted_func
+        self.assertEqual(
+            allowed[taxable_summary.preview_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.apply_taxable_summary_refresh], ["POST"]
+        )
+        self.assertEqual(
+            allowed[taxable_summary.download_taxable_summary_csv], ["POST"]
+        )
+
+    @patch("nepal_compliance.taxable_summary.frappe.db.commit")
+    @patch("nepal_compliance.taxable_summary._apply_change")
+    @patch("nepal_compliance.taxable_summary._compute_refresh_row")
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows")
+    def test_apply_updates_only_selected_invoice(
+        self, iter_rows, compute, apply_change, _commit
+    ):
+        selected_row = frappe._dict(name="PINV-1")
+        other_row = frappe._dict(name="PINV-2")
+        iter_rows.return_value = iter(
+            [
+                ("Purchase Invoice", selected_row),
+                ("Purchase Invoice", other_row),
+            ]
+        )
+        change = {"calculation_check": {"has_vat_mismatch": False}}
+        compute.return_value = ("changed", change)
+
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Purchase Invoice", "name": "PINV-1"}],
+            True,
+        )
+
+        compute.assert_called_once_with("Purchase Invoice", selected_row, True)
+        apply_change.assert_called_once_with(change)
+        self.assertEqual(result["updated"], 1)
+
+    def test_csv_contains_selected_preview_row(self):
+        data = taxable_summary.taxable_summary_csv_data(
+            [
+                {
+                    "document_type": "Purchase Invoice",
+                    "name": "YTPI-1",
+                    "posting_date": "2026-08-24",
+                    "company": "ACME",
+                    "old_taxable_amount": 4849.5,
+                    "new_taxable_amount": 5091.98,
+                    "old_non_taxable_amount": 0,
+                    "new_non_taxable_amount": 0,
+                    "old_vat_amount": 661.96,
+                    "new_vat_amount": 661.96,
+                    "old_summary_grand_total": 5753.93,
+                    "new_summary_grand_total": 5753.93,
+                    "would_change": True,
+                    "vat_on_added_taxes": True,
+                    "calculation_check": {
+                        "expected_vat": 661.96,
+                        "recorded_vat": 661.96,
+                        "vat_difference": 0,
+                        "has_vat_mismatch": False,
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(data[0], taxable_summary.TAXABLE_SUMMARY_CSV_COLUMNS)
+        self.assertEqual(data[1][1], "YTPI-1")
+        self.assertEqual(data[1][13], "Includes added taxes")
+        self.assertEqual(data[1][17], "OK")
 
 
 if __name__ == "__main__":

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from nepal_compliance import utils
+
+
+class TestTaxableSummaryCalculation(unittest.TestCase):
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_non_taxable_item_flag_classifies_item_totals(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=32762.94,
+            items=[
+                frappe._dict(
+                    item_code="Taxable", net_amount=4189.33, is_nontaxable_item=0
+                ),
+                frappe._dict(
+                    item_code="Non-Taxable",
+                    net_amount=28029,
+                    is_nontaxable_item=1,
+                ),
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    tax_amount_after_discount_amount=544.61,
+                    item_wise_tax_detail={"Taxable": [13, 544.61]},
+                )
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 4189.33)
+        self.assertEqual(invoice.non_taxable_amount, 28029)
+        self.assertEqual(invoice.vat_amount, 544.61)
+        self.assertFalse(check["has_vat_mismatch"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_previous_row_vat_includes_excise_in_taxable_base(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            grand_total=5753.9318,
+            items=[
+                frappe._dict(
+                    item_code="Y101642",
+                    net_amount=4849.5,
+                    is_nontaxable_item=0,
+                )
+            ],
+            taxes=[
+                frappe._dict(
+                    account_head="Import Duty",
+                    charge_type="On Net Total",
+                    tax_amount_after_discount_amount=0,
+                    item_wise_tax_detail={"Y101642": [0, 0]},
+                ),
+                frappe._dict(
+                    account_head="Excise",
+                    charge_type="On Previous Row Total",
+                    tax_amount_after_discount_amount=242.475,
+                    item_wise_tax_detail={"Y101642": [5, 242.475]},
+                ),
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Previous Row Total",
+                    tax_amount_after_discount_amount=661.9568,
+                    item_wise_tax_detail={"Y101642": [13, 661.95675]},
+                ),
+            ],
+        )
+
+        check = utils.set_taxable_amounts(
+            invoice, None, consider_is_non_taxable_item=True
+        )
+
+        self.assertEqual(invoice.taxable_amount, 5091.98)
+        self.assertEqual(check["expected_vat"], 661.96)
+        self.assertEqual(check["recorded_vat"], 661.96)
+        self.assertFalse(check["has_vat_mismatch"])
+        self.assertTrue(check["vat_on_added_taxes"])
+
+    @patch("nepal_compliance.utils.get_configured_vat_accounts")
+    def test_on_net_total_vat_does_not_include_added_taxes(self, configured):
+        configured.return_value = {
+            "ACME": {"purchase": "VAT Receivable", "sales": "VAT Payable"}
+        }
+        invoice = frappe._dict(
+            doctype="Purchase Invoice",
+            company="ACME",
+            taxes=[
+                frappe._dict(
+                    account_head="VAT Receivable",
+                    charge_type="On Net Total",
+                )
+            ],
+        )
+
+        self.assertFalse(utils.vat_charged_on_added_taxes(invoice))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nepal_compliance/test/test_taxable_summary.py
+++ b/nepal_compliance/test/test_taxable_summary.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import frappe
 
@@ -185,6 +185,67 @@ class TestSelectableTaxableSummary(unittest.TestCase):
         self.assertEqual(data[1][1], "YTPI-1")
         self.assertEqual(data[1][13], "Includes added taxes")
         self.assertEqual(data[1][17], "OK")
+
+    @patch("nepal_compliance.taxable_summary.frappe.get_doc")
+    @patch("nepal_compliance.taxable_summary.frappe.db.set_value")
+    def test_vat_mismatch_adds_error_tag_and_comment(self, _set_value, get_doc):
+        doc = Mock()
+        get_doc.return_value = doc
+        change = {
+            "doctype": "Sales Invoice",
+            "name": "YTCN-1",
+            "old_taxable_amount": 1663.7,
+            "new_taxable_amount": 1796.44,
+            "old_non_taxable_amount": 132.74,
+            "new_non_taxable_amount": 0,
+            "old_vat_amount": 216.28,
+            "new_vat_amount": 216.28,
+            "old_summary_grand_total": 2012.72,
+            "new_summary_grand_total": 2012.72,
+            "summary_grand_total": 2012.72,
+            "item_vat_detail": None,
+            "calculation_check": {
+                "expected_vat": 233.54,
+                "recorded_vat": 216.28,
+                "vat_difference": -17.26,
+                "has_vat_mismatch": True,
+            },
+        }
+
+        taxable_summary._apply_change(change)
+
+        doc.add_tag.assert_called_once_with("VAT Accounting Error")
+        comments = [call.args[1] for call in doc.add_comment.call_args_list]
+        self.assertTrue(any("VAT Accounting Error" in text for text in comments))
+        self.assertTrue(any("accounting has 216.28" in text for text in comments))
+
+    @patch("nepal_compliance.taxable_summary.frappe.db.commit")
+    @patch("nepal_compliance.taxable_summary._flag_invoice")
+    @patch("nepal_compliance.taxable_summary._apply_change")
+    @patch("nepal_compliance.taxable_summary._compute_refresh_row")
+    @patch("nepal_compliance.taxable_summary._iter_invoice_rows")
+    def test_warning_only_invoice_is_tagged_without_summary_write(
+        self, iter_rows, compute, apply_change, flag_invoice, _commit
+    ):
+        row = frappe._dict(name="YTCN-1")
+        iter_rows.return_value = iter([("Sales Invoice", row)])
+        change = {
+            "would_change": False,
+            "calculation_check": {"has_vat_mismatch": True},
+        }
+        compute.return_value = ("warning", change)
+
+        result = taxable_summary._run_apply(
+            "2026-01-01",
+            "2026-12-31",
+            [{"doctype": "Sales Invoice", "name": "YTCN-1"}],
+            True,
+        )
+
+        apply_change.assert_not_called()
+        flag_invoice.assert_called_once_with(change)
+        self.assertEqual(result["updated"], 1)
+        self.assertEqual(result["calculation_warnings"], 1)
 
 
 if __name__ == "__main__":

--- a/nepal_compliance/utils.py
+++ b/nepal_compliance/utils.py
@@ -236,6 +236,28 @@ def tax_row_amount(tax):
         else tax.tax_amount
     )
 
+PREVIOUS_ROW_VAT_CHARGE_TYPES = ("On Previous Row Total", "On Previous Row Amount")
+
+
+def vat_charged_on_added_taxes(doc, vat_account=None):
+    """True when VAT is calculated on a previous tax row (duty, excise, etc.).
+
+    Item-net × 13% is not the VAT base in that stack, so Taxable Summary
+    Refresh must not rewrite these invoices from the itemwise check.
+    """
+    if doc.doctype not in ("Sales Invoice", "Purchase Invoice"):
+        return False
+    if not vat_account:
+        side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
+        vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
+    if not vat_account:
+        return False
+    return any(
+        tax.account_head == vat_account
+        and tax.charge_type in PREVIOUS_ROW_VAT_CHARGE_TYPES
+        for tax in (doc.get("taxes") or [])
+    )
+
 VAT_EXEMPT_TEMPLATE_TITLE = "VAT Exempt"
 
 def get_configured_vat_accounts():
@@ -379,7 +401,13 @@ def validate_duplicate_bill_no(doc, method):
                 )
             )
 
-def set_taxable_amounts(doc, method):
+def set_taxable_amounts(doc, method, consider_is_non_taxable_item=False):
+    """Set IRD taxable summary fields and return an optional VAT calculation check.
+
+    The normal document-event path keeps the historical item-wise VAT
+    classification. The settings recompute can instead classify items solely
+    from the item's Is Non-Taxable Item flag.
+    """
     side = "sales" if doc.doctype == "Sales Invoice" else "purchase"
     vat_account = get_configured_vat_accounts().get(doc.company, {}).get(side)
 
@@ -389,26 +417,39 @@ def set_taxable_amounts(doc, method):
         for tax in doc.get("taxes") or []:
             if tax.account_head != vat_account:
                 continue
-            vat_amount += flt(
-                tax.tax_amount_after_discount_amount
-                if tax.tax_amount_after_discount_amount is not None
-                else tax.tax_amount
-            )
-            detail = tax.item_wise_tax_detail
-            if isinstance(detail, str):
-                try:
-                    detail = json.loads(detail)
-                except (TypeError, ValueError):
-                    detail = {}
-            for item_key, rate_amount in (detail or {}).items():
-                if isinstance(rate_amount, (list, tuple)) and len(rate_amount) > 1:
-                    item_vat[item_key] = item_vat.get(item_key, 0.0) + flt(rate_amount[1])
+            vat_amount += tax_row_amount(tax)
+            add_item_wise_vat(item_vat, tax.item_wise_tax_detail)
+
+    items = list(doc.get("items") or [])
+    row_vat = distribute_item_vat(items, item_vat)
+    include_added_taxes = vat_charged_on_added_taxes(doc, vat_account)
 
     taxable_amount = non_taxable_amount = 0.0
-    for item in doc.get("items") or []:
+    force_all_non_taxable = bool(
+        doc.get("is_pan_or_abbreviated_bill")
+        or (
+            doc.doctype == "Purchase Invoice"
+            and (not doc.get("taxes") or not flt(vat_amount))
+        )
+    )
+    for item, item_row_vat in zip(items, row_vat, strict=True):
         amt = flt(item.get("net_amount"))
-        if item.get("is_nontaxable_item") or not flt(item_vat.get(item.get("item_code") or item.get("item_name"))):
+        if consider_is_non_taxable_item:
+            is_non_taxable = bool(
+                force_all_non_taxable or item.get("is_nontaxable_item")
+            )
+        else:
+            item_key = item.get("item_code") or item.get("item_name")
+            is_non_taxable = bool(
+                item.get("is_nontaxable_item")
+                or not flt(parse_item_vat_entry(item_vat.get(item_key))[1])
+            )
+        if is_non_taxable:
             non_taxable_amount += amt
+        elif include_added_taxes:
+            # VAT was charged on net + prior rows (duty/excise). Use VAT ÷ rate
+            # so expected VAT is 13% of that same base.
+            taxable_amount += item_taxable_amount(item, item_row_vat, item_vat)
         else:
             taxable_amount += amt
 
@@ -418,6 +459,20 @@ def set_taxable_amounts(doc, method):
     # Bill Total is grand_total plus TDS: ERPNext deducts TDS from grand_total,
     # IRD wants the billed value (net + VAT) before withholding.
     set_bill_total(doc, vat_account)
+
+    if not consider_is_non_taxable_item:
+        return None
+
+    expected_vat = flt(taxable_amount * 0.13, 2)
+    recorded_vat = flt(vat_amount, 2)
+    difference = flt(recorded_vat - expected_vat, 2)
+    return {
+        "expected_vat": expected_vat,
+        "recorded_vat": recorded_vat,
+        "vat_difference": difference,
+        "has_vat_mismatch": abs(difference) >= 0.01,
+        "vat_on_added_taxes": include_added_taxes,
+    }
 
 def get_vat_breakup(invoice_doctype, invoice_company_map):
     """


### PR DESCRIPTION
## Summary
- Add contextual help to Audit TDS Bases.
- Explain transaction-currency and company-currency TDS bases.
- Clarify that applying the audit only updates TDS base fields.
- Clarify that historical TDS, VAT rows, and GL entries are unchanged.

Depends on #363. Merge after #363; this PR will shrink to its focused diff then.